### PR TITLE
Add multidimensional (z + timelapse) tile stitching

### DIFF
--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -208,6 +208,7 @@ You need the XLIF metadata file and the directory with the PTU tiles. The XLIF i
 - **Stitch only** builds a stitched intensity image and FLIM histogram cube, skips fitting. Exports the FLIM cube as an `.npy` file. Good for a quick visual check or if you want to hand the data off to something else.
 - **Stitch then fit full ROI** stitches everything into a single mosaic and fits it. Not recommended unless you have a capable machine and a small tile count, fitting a full mosaic requires a lot of RAM (tens of GBs) and is slow.
 - **Per-tile fit** the recommended option for most cases. Builds a global decay from all tiles, runs an initial fit to get the lifetime components, then fits each tile separately using those fixed lifetimes. Results are stitched back together at the end. Same quality as fitting the mosaic directly, but far more memory-efficient.
+- **Multidimensional series** per-tile fit repeated over a z and/or time axis, writing one stitched plane per `(t, z)`. Does not need an XLIF: tile positions are recovered from the tile overlap. See [Multidimensional Series](#multidimensional-series-stitched-tiles-over-z-and-time).
 
 Fitting parameters are the same as for single FOV. For tile work, the machine IRF is strongly recommended, per-tile XLSX IRFs from FLIM microscope software can vary across tiles and cause inconsistencies.
 
@@ -468,6 +469,28 @@ Expected filename patterns: `region_tX[_sY][_zZ].ptu` for timelapse, `region_zX.
 `--nexp`, `--tau-min`, `--tau-max`, `--machine-irf`, `--estimate-irf`, `--irf-fwhm`, `--irf-bins`, `--irf-fit-width`, `--optimizer`, `--restarts`, `--de-population`, `--de-maxiter`, `--workers`, `--no-polish`, `--channel`, `--min-photons`, `--cost-function` and `--no-plots` behave as in `fit_cli.py`.
 
 Outputs land under `output-dir` in one folder per group: per-slice amplitude/intensity/lifetime maps, the pooled reference fit as `*_reference_fit.json`, stacked maps, and a series summary as `*_zseries.csv` / `.json` / `.png` (`*_timeseries.csv` for timelapse).
+
+These treat each `_sY` position as an independent field of view. If the positions are overlapping tiles of one larger region, use the multidimensional series fit below instead, which stitches them.
+
+#### Multidimensional Series (stitched tiles over z and time)
+
+For tiled acquisitions with a z and/or time axis, where the tiles overlap and should be stitched into one canvas per plane rather than fitted as separate fields of view.
+
+Stitch tab → pipeline "Multidimensional series". The XLIF field is not required: tile positions are recovered from the tile overlap itself, by maximising the correlation between neighbouring tiles over candidate shifts. FFT phase correlation is not used, because on real mosaics with ~10% overlap it returns no distinguishable peak.
+
+One pooled decay is fitted across the whole series, and every plane is then fitted per-pixel with those τ values locked, so amplitudes stay comparable between timepoints. "Pool decay every N timepoints" subsamples that pooling step, which only needs photon statistics rather than every file.
+
+Filenames follow the same `region_tX[_sY][_zZ].ptu` convention as the timelapse fit, and at least two positions are required.
+
+```python
+from flimkit.formats.PTU.stitch import fit_flim_series
+
+manifest = fit_flim_series(ptu_dir, output_dir, args, pool_stride=10)
+```
+
+Outputs are one directory per `(t, z)` plane, each holding the usual fitted maps, plus a `*_series_index.json` manifest recording the recovered tile positions, the consensus τ values and every plane written. Tile positions can be supplied directly as `tile_positions=` to skip recovery.
+
+Registration quality is reported as a correlation per tile pair. A low value means the overlap was not found, usually because the tiles genuinely do not overlap or the region is too sparse to register; supply positions from a `.lif` or `.xlif` in that case.
 
 #### Fit window and exclusion bands
 

--- a/flimkit/UI/controller.py
+++ b/flimkit/UI/controller.py
@@ -64,13 +64,18 @@ class FLIMKitController:
         ptu_dir = self.b.sv_ptu_dir.get().strip()
         out_base = self.b.sv_out_st.get().strip()
         pipeline = self.b.sv_pipeline.get()
-        roi_name = Path(xlif).stem.replace(' ', '_')
+        if pipeline == 'series_fit' and not xlif:
+            roi_name = Path(ptu_dir).name.replace(' ', '_') or 'series'
+            ptu_basename = None
+        else:
+            roi_name = Path(xlif).stem.replace(' ', '_')
+            ptu_basename = Path(xlif).stem
         output_dir = str(Path(out_base) / roi_name)
         a = argparse.Namespace()
         a.xlif = xlif
         a.ptu_dir = ptu_dir
         a.output_dir = output_dir
-        a.ptu_basename = Path(xlif).stem
+        a.ptu_basename = ptu_basename
         a.rotate_tiles = self.b.bv_rotate.get()
         cfg = _C()
         irf = self.b._irf_st.get_args()

--- a/flimkit/UI/fov_preview.py
+++ b/flimkit/UI/fov_preview.py
@@ -66,6 +66,7 @@ class FOVPreviewPanel:
         self._zbar = zbar
         zbar.grid_remove()
         self._zstack = None
+        self._series = None
         self._z_i = 0
         ttk.Label(ctrl_frame, text='τ range (ns):').grid(row=0, column=0, sticky='w')
         ttk.Label(ctrl_frame, text='Min:').grid(row=0, column=1, sticky='w', padx=(10, 2))
@@ -402,10 +403,41 @@ class FOVPreviewPanel:
 
     def _hide_zstack(self):
         self._zstack = None
+        self._series = None
         try:
             self._zbar.grid_remove()
         except Exception:
             pass
+
+    def display_series(self, planes, output_dir):
+        self._zstack = None
+        self._series = [dict(p, _root=str(output_dir)) for p in planes] if planes else None
+        if not self._series:
+            self._hide_zstack()
+            return
+        self._z_slider.configure(to=max(len(self._series) - 1, 0))
+        self._zbar.grid()
+        self._z_i = 0
+        self._sync_z_slider()
+        self._show_series_plane(0)
+
+    def _series_plane_label(self, desc, i):
+        parts = []
+        if desc.get('t') is not None:
+            parts.append(f"t{desc['t']}")
+        if desc.get('z') is not None:
+            parts.append(f"z{desc['z']}")
+        head = ' '.join(parts) or desc.get('name', '')
+        return f"{head}  ({i + 1}/{len(self._series)})"
+
+    def _show_series_plane(self, i):
+        desc = self._series[i]
+        self._z_label.set(self._series_plane_label(desc, i))
+        plane_dir = Path(desc['_root']) / desc.get('dir', desc.get('name', ''))
+        keep = self._series
+        self.load_stitched_roi(str(plane_dir))
+        self._series = keep
+        self._zbar.grid()
 
     def _sync_z_slider(self):
         self._z_slider_updating = True
@@ -415,11 +447,18 @@ class FOVPreviewPanel:
             self._z_slider_updating = False
 
     def _on_z_slider(self, value):
-        if self._z_slider_updating or not self._zstack:
+        if self._z_slider_updating:
             return
-        i = max(0, min(int(round(float(value))), len(self._zstack) - 1))
-        if i != self._z_i:
-            self._z_i = i
+        stack = self._series or self._zstack
+        if not stack:
+            return
+        i = max(0, min(int(round(float(value))), len(stack) - 1))
+        if i == self._z_i:
+            return
+        self._z_i = i
+        if self._series:
+            self._show_series_plane(i)
+        else:
             self._show_zstack_slice(i)
 
     def _show_zstack_slice(self, i):
@@ -829,14 +868,6 @@ class FOVPreviewPanel:
         self._decay_visible = show
         self._rebuild_layout()
     def _rebuild_layout(self):
-        """Rebuild the GridSpec layout based on decay visibility.
-        Decay visible (default):
-            Row 0: [Intensity] [FLIM] [cbar]     height_ratio 1
-            Row 1: [       Decay          ]       height_ratio 0.6
-        Decay hidden:
-            Row 0: [    FLIM   ] [cbar]           height_ratio 1
-            Row 1: [ Intensity ]                  height_ratio 0.5
-        """
         from matplotlib.gridspec import GridSpec
         flim_title = self._ax_flim.get_title() if self._ax_flim.get_visible() else 'FLIM Lifetime (ns)'
         img_title = self._ax_img.get_title() if self._ax_img.get_visible() else 'Intensity'

--- a/flimkit/UI/gui.py
+++ b/flimkit/UI/gui.py
@@ -2206,12 +2206,27 @@ Anthropic's Claude AI assisted with parts of the GUI implementation.
             self._btn_st.configure(text='▶  Run Stitch + Fit')
             self._btn_expert_st.pack(side='left', padx=4, before=self._btn_st)
             self._update_expert_banners()
+        elif mode == 'series_fit':
+            self._fit_frame.grid()
+            self._tile_extras_frame.grid_remove()
+            if hasattr(self, '_series_frame'):
+                self._series_frame.grid()
+            self._btn_st.configure(text='▶  Run Series Fit')
+            self._btn_expert_st.pack(side='left', padx=4, before=self._btn_st)
+            self._update_expert_banners()
         else:
             self._fit_frame.grid()
             self._tile_extras_frame.grid()
             self._btn_st.configure(text='▶  Run Per-Tile Fit')
             self._btn_expert_st.pack(side='left', padx=4, before=self._btn_st)
             self._update_expert_banners()
+        if mode != 'series_fit' and hasattr(self, '_series_frame'):
+            self._series_frame.grid_remove()
+        if hasattr(self, '_xlif_optional_note'):
+            if mode == 'series_fit':
+                self._xlif_optional_note.grid()
+            else:
+                self._xlif_optional_note.grid_remove()
         self._update_form_scrollbar('stitch')
         self.root.after_idle(self._fit_window_to_screen)
 
@@ -3092,13 +3107,22 @@ Anthropic's Claude AI assisted with parts of the GUI implementation.
         xlif = self.sv_xlif.get().strip()
         ptu_dir = self.sv_ptu_dir.get().strip()
         out_base = self.sv_out_st.get().strip()
-        for val, name in [(xlif, 'XLIF file'),
-                          (ptu_dir, 'PTU directory'),
-                          (out_base, 'Output directory')]:
+        pipeline = self.sv_pipeline.get()
+        required = [(ptu_dir, 'PTU directory'), (out_base, 'Output directory')]
+        if pipeline != 'series_fit':
+            required.insert(0, (xlif, 'XLIF file'))
+        for val, name in required:
             if not val:
                 messagebox.showerror('Missing input', f'Please specify the {name}.')
                 return
-        pipeline = self.sv_pipeline.get()
+        pool_stride = 10
+        if pipeline == 'series_fit':
+            try:
+                pool_stride = max(1, int(self.sv_pool_stride.get() or 10))
+            except ValueError:
+                messagebox.showerror('Invalid input',
+                                     'Pool decay every N timepoints must be a whole number.')
+                return
         from flimkit.formats.PTU.stitch import stitch_flim_tiles
         a = self._controller.stitch_args()
 
@@ -3151,6 +3175,20 @@ Anthropic's Claude AI assisted with parts of the GUI implementation.
                         self._stitch_roi_panel._refresh_region_list()
                 except Exception:
                     pass
+            elif pipeline == 'series_fit' and isinstance(result, dict):
+                planes = result.get('planes', [])
+                taus = result.get('consensus_taus_ns', [])
+                print(f"\n  {len(planes)} plane(s) written under {a.output_dir}")
+                print(f"  Manifest: {result.get('base', '')}_series_index.json")
+                if taus:
+                    print(f"  Consensus τ = {[f'{t:.3f}' for t in taus]} ns")
+                if planes:
+                    self._res.set_status(
+                        f'✓  {len(planes)} planes fitted - drag the slider to browse them')
+                    try:
+                        self._fov_preview.display_series(planes, a.output_dir)
+                    except Exception as e:
+                        print(f'Warning: Could not load series planes: {e}')
             else:
                 try:
                     self._fov_preview.load_stitched_roi(a.output_dir)
@@ -3177,13 +3215,25 @@ Anthropic's Claude AI assisted with parts of the GUI implementation.
                 from flimkit.interactive import _run_stitch_and_fit
                 return _run_stitch_and_fit(a, progress_callback=progress_callback,
                                            cancel_event=cancel_event)
+            elif pipeline == 'series_fit':
+                from flimkit.formats.PTU.stitch import fit_flim_series
+                return fit_flim_series(
+                    ptu_dir=a.ptu_dir,
+                    output_dir=a.output_dir,
+                    args=a,
+                    rotate_tiles=a.rotate_tiles,
+                    pool_stride=pool_stride,
+                    verbose=True,
+                    progress_callback=progress_callback,
+                    cancel_event=cancel_event,
+                )
             else:
                 from flimkit.interactive import _run_tile_fit
                 return _run_tile_fit(a, progress_callback=progress_callback,
                                      cancel_event=cancel_event)
         self._set_buttons('disabled')
         task_name = {'stitch_only': 'Stitching', 'stitch_fit': 'Stitch + Fit',
-                     'tile_fit': 'Per-Tile Fit'}[pipeline]
+                     'tile_fit': 'Per-Tile Fit', 'series_fit': 'Series Fit'}[pipeline]
         self.run_with_progress(task, task_name=task_name, on_done=on_done, output_dir=a.output_dir)
 
     def _run_phasor(self):

--- a/flimkit/UI/modes/stitch_mode.py
+++ b/flimkit/UI/modes/stitch_mode.py
@@ -14,14 +14,20 @@ class StitchMode(BaseMode):
         ff = _section(tab, 'Input Files')
         ff.grid(row=0, column=0, sticky='ew', pady=(0, 6))
         ff.columnconfigure(1, weight=1)
-        self.b.state.sv_xlif    = tk.StringVar()
+        self.b.state.sv_xlif = tk.StringVar()
         self.b.sv_xlif.trace_add('write', self.b._on_xlif_changed)
         self.b.state.sv_ptu_dir = tk.StringVar()
-        self.b.state.sv_out_st  = tk.StringVar()
+        self.b.state.sv_out_st = tk.StringVar()
 
         _row(ff, 'XLIF metadata *',      self.b.sv_xlif,    0,
              lambda: _browse_file(self.b.sv_xlif, 'XLIF file',
                                   [('XLIF', '*.xlif'), ('All', '*.*')]))
+        self.b._xlif_optional_note = ttk.Label(
+            ff, text='Not needed for a multidimensional series: tile positions '
+                     'are recovered from the tile overlap',
+            foreground='grey')
+        self.b._xlif_optional_note.grid(row=0, column=3, sticky='w', padx=4)
+        self.b._xlif_optional_note.grid_remove()
         _row(ff, 'PTU tile directory *', self.b.sv_ptu_dir, 1,
              lambda: _browse_dir(self.b.sv_ptu_dir, 'PTU tile directory'))
         _row(ff, 'Base output dir *',    self.b.sv_out_st,  2,
@@ -40,8 +46,9 @@ class StitchMode(BaseMode):
         self.b.state.sv_pipeline = tk.StringVar(value='stitch_only')
         for r, (val, lbl) in enumerate([
             ('stitch_only', 'Stitch tiles only'),
-            ('stitch_fit',  'Stitch then fit full ROI'),
-            ('tile_fit',    'Per-tile fit  [recommended - fits each tile independently]'),
+            ('stitch_fit', 'Stitch then fit full ROI'),
+            ('tile_fit', 'Per-tile fit  [recommended - fits each tile independently]'),
+            ('series_fit', 'Multidimensional series  [z-stack and/or timelapse tiles]'),
         ]):
             ttk.Radiobutton(fp, text=lbl, variable=self.b.sv_pipeline,
                             value=val, command=self.b._pipeline_changed).grid(
@@ -215,6 +222,28 @@ class StitchMode(BaseMode):
             row=1, column=1, sticky='w', padx=4)
         ttk.Label(freg, text='(increase if drift > 120px)',
                   foreground='grey').grid(row=1, column=2, sticky='w')
+
+        self.b._series_frame = ttk.Frame(parent)
+        self.b._series_frame.columnconfigure(0, weight=1)
+        self.b._series_frame.grid(row=5, column=0, sticky='ew', pady=(0, 4))
+        fsr = _section(self.b._series_frame, 'Multidimensional Series')
+        fsr.grid(row=0, column=0, sticky='ew')
+        ttk.Label(fsr, text='Pool decay every N timepoints:').grid(
+            row=0, column=0, sticky='w', **PAD)
+        self.b.state.sv_pool_stride = tk.StringVar(value='10')
+        ttk.Entry(fsr, textvariable=self.b.sv_pool_stride, width=6).grid(
+            row=0, column=1, sticky='w', padx=4)
+        ttk.Label(fsr, text='(1 = every timepoint; higher is faster, same consensus)',
+                  foreground='grey').grid(row=0, column=2, sticky='w')
+        ttk.Label(fsr, text='One consensus lifetime is fitted across the whole series, '
+                            'so amplitudes stay comparable between timepoints.',
+                  foreground='grey', wraplength=520, justify='left').grid(
+            row=1, column=0, columnspan=3, sticky='w', padx=8, pady=(2, 0))
+        ttk.Label(fsr, text='Tile positions are recovered from the tile overlap; '
+                            'the reported correlation shows whether that worked.',
+                  foreground='grey', wraplength=520, justify='left').grid(
+            row=2, column=0, columnspan=3, sticky='w', padx=8)
+        self.b._series_frame.grid_remove()
 
         self.b._tile_extras_frame = ttk.Frame(parent)
         self.b._tile_extras_frame.columnconfigure(0, weight=1)

--- a/flimkit/formats/PTU/series.py
+++ b/flimkit/formats/PTU/series.py
@@ -1,0 +1,212 @@
+import re
+import numpy as np
+from pathlib import Path
+
+TILE_ONLY_PATTERN = re.compile(r'^(?P<base>.+?)_s(?P<s>\d+)\.ptu$', re.IGNORECASE)
+
+def parse_series_name(name):
+    from ...utils.batch_fit import parse_timelapse_filename
+    name = str(name)
+    parsed = parse_timelapse_filename(name)
+    if parsed is not None:
+        region, t, s, z = parsed
+        return {
+            'file': name,
+            'base': region,
+            't': t,
+            's': s or 1,
+            'z': z or 1,
+            'has_t': True,
+            'has_z': z > 0,
+        }
+    m = TILE_ONLY_PATTERN.match(name)
+    if m is None:
+        return None
+    return {
+        'file': name,
+        'base': m.group('base'),
+        't': 1,
+        's': int(m.group('s')),
+        'z': 1,
+        'has_t': False,
+        'has_z': False,
+    }
+
+def index_ptu_series(ptu_dir, ptu_basename=None):
+    ptu_dir = Path(ptu_dir)
+    entries = []
+    for path in sorted(ptu_dir.glob('*.ptu')):
+        parsed = parse_series_name(path.name)
+        if parsed is None:
+            continue
+        if ptu_basename is not None and parsed['base'] != ptu_basename:
+            continue
+        entries.append(parsed)
+    if not entries:
+        raise RuntimeError(
+            f'No PTU files matching <base>_s<N>[_z<N>] found in {ptu_dir}'
+            + (f' for basename {ptu_basename!r}' if ptu_basename else ''))
+    bases = sorted({e['base'] for e in entries})
+    if len(bases) > 1:
+        raise RuntimeError(
+            f'Multiple series in {ptu_dir}: {bases}. Pass ptu_basename to pick one.')
+    planes = {}
+    for e in entries:
+        planes.setdefault((e['t'], e['z']), []).append(e)
+    for key in planes:
+        planes[key].sort(key=lambda e: e['s'])
+    tile_counts = {len(v) for v in planes.values()}
+    tiles = sorted({e['s'] for e in entries})
+    if len(tiles) < 2:
+        raise RuntimeError(
+            f'{bases[0]!r} has a single position, so there is nothing to stitch. '
+            'Use the timelapse or z-stack batch fit for single-position stacks.')
+    return {
+        'base': bases[0],
+        'planes': planes,
+        'timepoints': sorted({t for t, _ in planes}),
+        'z_planes': sorted({z for _, z in planes}),
+        'tiles': tiles,
+        'n_files': len(entries),
+        'is_ragged': len(tile_counts) > 1,
+        'has_t': any(e['has_t'] for e in entries),
+        'has_z': any(e['has_z'] for e in entries),
+    }
+
+def describe_series(index):
+    n_t = len(index['timepoints'])
+    n_z = len(index['z_planes'])
+    n_s = len(index['tiles'])
+    return (f"{index['base']!r}: {n_t} timepoint(s) x {n_s} tile(s) x {n_z} z-plane(s) "
+            f"= {index['n_files']} files")
+
+def _overlap_score(a, b, dy, dx, min_px):
+    h, w = a.shape
+    pa = a[max(0, dy):min(h, h + dy), max(0, dx):min(w, w + dx)]
+    pb = b[max(0, -dy):min(h, h - dy), max(0, -dx):min(w, w - dx)]
+    if pa.size < min_px:
+        return None
+    pa = pa - pa.mean()
+    pb = pb - pb.mean()
+    den = np.sqrt(float((pa * pa).sum()) * float((pb * pb).sum()))
+    if den <= 0:
+        return None
+    return float((pa * pb).sum() / den), pa.size
+
+def register_tile_pair(image_a, image_b, coarse_step=4, refine_radius=8,
+                       min_overlap_frac=0.05, n_candidates=8):
+    a = np.log1p(np.asarray(image_a, dtype=float))
+    b = np.log1p(np.asarray(image_b, dtype=float))
+    if a.shape != b.shape:
+        raise ValueError(f'Tile shapes differ: {a.shape} vs {b.shape}')
+    h, w = a.shape
+    min_px = max(1, int(min_overlap_frac * a.size))
+    coarse = []
+    for dy in range(-h + 1, h, coarse_step):
+        for dx in range(-w + 1, w, coarse_step):
+            scored = _overlap_score(a, b, dy, dx, min_px)
+            if scored is None:
+                continue
+            coarse.append((scored[0], dy, dx, scored[1]))
+    if not coarse:
+        raise RuntimeError(
+            f'No candidate shift kept at least {100 * min_overlap_frac:.0f}% overlap')
+    coarse.sort(key=lambda c: (-c[0], -c[3]))
+    best = None
+    for _, cy, cx, _ in coarse[:n_candidates]:
+        for dy in range(cy - refine_radius, cy + refine_radius + 1):
+            for dx in range(cx - refine_radius, cx + refine_radius + 1):
+                scored = _overlap_score(a, b, dy, dx, min_px)
+                if scored is None:
+                    continue
+                r, n = scored
+                if best is None or r > best[0] + 1e-9 or (
+                        abs(r - best[0]) <= 1e-9 and n > best[3]):
+                    best = (r, dy, dx, n)
+    r, dy, dx, n_px = best
+    return {
+        'dy': int(dy),
+        'dx': int(dx),
+        'correlation': float(r),
+        'overlap_px': int(n_px),
+        'overlap_frac': float(n_px) / float(a.size),
+    }
+
+def recover_tile_positions(tile_images, min_correlation=0.3):
+    if len(tile_images) < 2:
+        raise ValueError('Need at least two tiles to recover positions')
+    shifts = {0: (0, 0)}
+    pairs = []
+    for i in range(1, len(tile_images)):
+        reg = register_tile_pair(tile_images[i - 1], tile_images[i])
+        if reg['correlation'] < min_correlation:
+            raise RuntimeError(
+                f'Tile {i-1} to {i} registration too weak '
+                f"(r={reg['correlation']:.3f} < {min_correlation}); "
+                f'supply tile positions from a .lif or .xlif instead')
+        prev_y, prev_x = shifts[i - 1]
+        shifts[i] = (prev_y + reg['dy'], prev_x + reg['dx'])
+        pairs.append(reg)
+    ys = [shifts[i][0] for i in range(len(tile_images))]
+    xs = [shifts[i][1] for i in range(len(tile_images))]
+    min_y, min_x = min(ys), min(xs)
+    positions = [{'pixel_y': ys[i] - min_y, 'pixel_x': xs[i] - min_x}
+                 for i in range(len(tile_images))]
+    return positions, pairs
+
+def _tile_intensity(ptu_path, rotate_cw, binning):
+    from .reader import PTUFile
+    ptu = PTUFile(str(ptu_path), verbose=False)
+    ptu.summed_decay()
+    img = ptu.intensity_image(channel=ptu.photon_channel, binning=binning)
+    if rotate_cw:
+        img = np.rot90(img, k=-1)
+    return img
+
+def recover_series_positions(ptu_dir, index, plane=None, rotate_tiles=True,
+                             binning=1, min_correlation=0.3, verbose=True):
+    ptu_dir = Path(ptu_dir)
+    if plane is None:
+        mid_t = index['timepoints'][len(index['timepoints']) // 2]
+        mid_z = index['z_planes'][len(index['z_planes']) // 2]
+        plane = (mid_t, mid_z)
+    entries = index['planes'].get(plane)
+    if not entries:
+        raise RuntimeError(f'Plane {plane} not present in series index')
+    if verbose:
+        print(f'Recovering tile positions from t={plane[0]} z={plane[1]} '
+              f'({len(entries)} tiles)...')
+    images = [_tile_intensity(ptu_dir / e['file'], rotate_tiles, binning)
+              for e in entries]
+    positions, pairs = recover_tile_positions(images, min_correlation=min_correlation)
+    tile_positions = []
+    for e, pos in zip(entries, positions):
+        tile_positions.append({
+            'file': e['file'],
+            's': e['s'],
+            'scan_index': e['s'] - 1,
+            'field_x': 0,
+            'field_y': e['s'] - 1,
+            'pos_x': 0.0,
+            'pos_y': 0.0,
+            'pixel_x': pos['pixel_x'],
+            'pixel_y': pos['pixel_y'],
+        })
+    if verbose:
+        for i, reg in enumerate(pairs):
+            print(f"  s{entries[i]['s']} to s{entries[i+1]['s']}: "
+                  f"dy={reg['dy']} dx={reg['dx']} r={reg['correlation']:.3f} "
+                  f"overlap={100 * reg['overlap_frac']:.1f}%")
+    return tile_positions, pairs
+
+def plane_tile_positions(reference_positions, entries):
+    by_tile = {p['s']: p for p in reference_positions}
+    out = []
+    for e in sorted(entries, key=lambda x: x['s']):
+        ref = by_tile.get(e['s'])
+        if ref is None:
+            raise RuntimeError(
+                f"Tile s{e['s']} has no recovered position; the reference plane "
+                f'was missing that tile')
+        out.append({**ref, 'file': e['file']})
+    return out

--- a/flimkit/formats/PTU/stitch.py
+++ b/flimkit/formats/PTU/stitch.py
@@ -609,6 +609,231 @@ def _register_tile_columns(tile_results, max_shift_px=120, verbose=True,):
         print(f'  Registration complete. Canvas: {canvas_h}×{canvas_w}px')
     return tile_results
 
+def pool_series_decay(ptu_dir, index, args, stride=10, rotate_tiles=True,
+                      verbose=True, cancel_event=None):
+    from .reader import PTUFile
+    from ...FLIM.fitters import fit_summed
+    from ...FLIM.bg_tools import tvb_from_decay
+    from ...configs import (
+        MACHINE_IRF_DEFAULT_PATH,
+        MACHINE_IRF_FIT_BG, MACHINE_IRF_FIT_SIGMA, MACHINE_IRF_FIT_TAIL,
+        MACHINE_IRF_SIGMA_MAX_FULL, MACHINE_IRF_SIGMA_MAX_HALF,
+        Tau_min, Tau_max, n_exp as _cfg_nexp,
+        Cost_function, Optimizer, lm_restarts, n_workers,
+    )
+    ptu_dir = Path(ptu_dir)
+    n_exp_ = getattr(args, 'nexp', _cfg_nexp)
+    fit_sigma = MACHINE_IRF_FIT_SIGMA
+    sigma_max = MACHINE_IRF_SIGMA_MAX_FULL
+    estimate_irf = getattr(args, 'estimate_irf', 'machine_irf')
+    if estimate_irf == 'machine_irf_sigma_full':
+        fit_sigma = True
+    elif estimate_irf == 'machine_irf_sigma_half':
+        fit_sigma = True
+        sigma_max = MACHINE_IRF_SIGMA_MAX_HALF
+    mach_path = getattr(args, 'machine_irf', str(MACHINE_IRF_DEFAULT_PATH))
+    machine_irf, pi_machine = _load_machine_irf(mach_path)
+    timepoints = index['timepoints'][::max(1, stride)]
+    planes = [k for k in sorted(index['planes']) if k[0] in set(timepoints)]
+    if verbose:
+        print(f'Pooling decay over {len(planes)} of {len(index["planes"])} planes '
+              f'(every {stride} timepoint(s))...')
+    pooled_decay = None
+    n_bins_ref = None
+    tcspc_ref = None
+    n_files = 0
+    for key in planes:
+        if cancel_event is not None and cancel_event.is_set():
+            break
+        for entry in index['planes'][key]:
+            path = ptu_dir / entry['file']
+            if not path.exists():
+                continue
+            ptu = PTUFile(str(path), verbose=False)
+            decay = ptu.summed_decay()
+            n_files += 1
+            if pooled_decay is None:
+                pooled_decay = decay.astype(np.float64).copy()
+                n_bins_ref = ptu.n_bins
+                tcspc_ref = ptu.tcspc_res
+                continue
+            if ptu.n_bins > n_bins_ref:
+                pooled_decay = np.pad(pooled_decay, (0, ptu.n_bins - n_bins_ref))
+                n_bins_ref = ptu.n_bins
+            if len(decay) < len(pooled_decay):
+                decay = np.pad(decay, (0, len(pooled_decay) - len(decay)))
+            pooled_decay[:len(decay)] += decay[:len(pooled_decay)]
+    if pooled_decay is None:
+        raise RuntimeError(f'No readable PTU files under {ptu_dir}')
+    pooled_peak = int(np.argmax(pooled_decay))
+    pooled_irf = _get_tile_irf(machine_irf, pi_machine, pooled_peak, n_bins_ref)
+    if verbose:
+        print(f'  Pooled {n_files} files, {pooled_decay.sum():,.0f} photons, '
+              f'peak bin {pooled_peak}')
+        print('  Running consensus fit_summed on pooled decay...')
+    _tvb_ptu_path = getattr(args, 'tvb_ptu', None)
+    _tvb_pooled = None
+    _fit_tvb = False
+    if _tvb_ptu_path:
+        _tvb_ref = PTUFile(str(_tvb_ptu_path), verbose=False)
+        _tvb_pooled = tvb_from_decay(
+            _tvb_ref.summed_decay(channel=getattr(args, 'tvb_channel', None)),
+            n_bins_ref, src_tcspc_res=_tvb_ref.tcspc_res, dst_tcspc_res=tcspc_ref)
+        _fit_tvb = True
+    global_popt, global_summary = fit_summed(
+        pooled_decay, tcspc_ref, n_bins_ref, pooled_irf,
+        has_tail = MACHINE_IRF_FIT_TAIL,
+        fit_bg = MACHINE_IRF_FIT_BG,
+        fit_sigma = fit_sigma,
+        n_exp = n_exp_,
+        tau_min_ns = getattr(args, 'tau_min', Tau_min),
+        tau_max_ns = getattr(args, 'tau_max', Tau_max),
+        optimizer = getattr(args, 'optimizer', Optimizer),
+        cost_function = getattr(args, 'cost_function', Cost_function),
+        n_restarts = getattr(args, 'restarts', lm_restarts),
+        workers = getattr(args, 'workers', n_workers),
+        sigma_max = sigma_max,
+        tvb_profile = _tvb_pooled,
+        fit_tvb = _fit_tvb,
+    )
+    if verbose:
+        taus = global_summary['taus_ns']
+        print(f"  Consensus τ = {[f'{t:.3f}' for t in taus]} ns")
+        print(f"  χ²_r (tail) = {global_summary['reduced_chi2_tail']:.4f}")
+    return {
+        'pooled_decay': pooled_decay,
+        'pooled_irf': pooled_irf,
+        'pooled_peak': pooled_peak,
+        'n_bins': n_bins_ref,
+        'tcspc': tcspc_ref,
+        'global_popt': global_popt,
+        'global_summary': global_summary,
+        'n_files_pooled': n_files,
+        'stride': stride,
+    }
+
+def fit_flim_series(
+    ptu_dir,
+    output_dir,
+    args,
+    ptu_basename=None,
+    rotate_tiles=True,
+    tile_positions=None,
+    pool_stride=10,
+    pooled=None,
+    verbose=True,
+    progress_callback=None,
+    cancel_event=None,
+):
+    from .series import index_ptu_series, describe_series, recover_series_positions, plane_tile_positions
+    from ...FLIM.assemble import assemble_tile_maps, save_assembled_maps
+    ptu_dir = Path(ptu_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    index = index_ptu_series(ptu_dir, ptu_basename=ptu_basename)
+    if verbose:
+        print(f"\n{'='*60}")
+        print('  MULTIDIMENSIONAL SERIES FIT')
+        print(f"{'='*60}")
+        print(f'  {describe_series(index)}')
+    if index['is_ragged']:
+        raise RuntimeError(
+            'Series has a different tile count on different planes; '
+            'the missing files must be restored before stitching')
+    if tile_positions is None:
+        tile_positions, _ = recover_series_positions(
+            ptu_dir, index, rotate_tiles=rotate_tiles,
+            binning=getattr(args, 'binning', 1), verbose=verbose)
+    if pooled is None:
+        pooled = pool_series_decay(
+            ptu_dir, index, args, stride=pool_stride,
+            rotate_tiles=rotate_tiles, verbose=verbose, cancel_event=cancel_event)
+    n_exp_ = getattr(args, 'nexp', 2)
+    roi_base = index['base'].replace(' ', '_')
+    planes = sorted(index['planes'])
+    written = []
+    for i, key in enumerate(planes):
+        if cancel_event is not None and cancel_event.is_set():
+            if verbose:
+                print('\nSeries fit cancelled by user.')
+            break
+        if progress_callback is not None:
+            progress_callback(i, len(planes))
+        t_index, z_index = key
+        plane_positions = plane_tile_positions(tile_positions, index['planes'][key])
+        plane_name = f'{roi_base}_t{t_index}_z{z_index}'
+        if verbose:
+            print(f"\n[{i+1}/{len(planes)}] t={t_index} z={z_index}")
+        (tile_results, canvas_h, canvas_w, corrected_positions,
+         _, _, _, _, plane_summary) = fit_flim_tiles(
+            xlif_path = None,
+            ptu_dir = ptu_dir,
+            output_dir = output_dir,
+            args = args,
+            ptu_basename = index['base'],
+            rotate_tiles = rotate_tiles,
+            verbose = False,
+            cancel_event = cancel_event,
+            tile_positions = plane_positions,
+            pooled = pooled,
+        )
+        if not tile_results:
+            if verbose:
+                print(f'  no tiles fitted for t={t_index} z={z_index}, skipped')
+            continue
+        canvas = assemble_tile_maps(
+            tile_results = tile_results,
+            canvas_height = canvas_h,
+            canvas_width = canvas_w,
+            n_exp = n_exp_,
+        )
+        plane_dir = output_dir / plane_name
+        save_assembled_maps(
+            canvas = canvas,
+            global_summary = plane_summary,
+            output_dir = plane_dir,
+            roi_name = plane_name,
+            n_exp = n_exp_,
+            tau_display_min = getattr(args, 'tau_display_min', None),
+            tau_display_max = getattr(args, 'tau_display_max', None),
+        )
+        written.append({
+            't': t_index,
+            'z': z_index,
+            'name': plane_name,
+            'dir': str(plane_dir.relative_to(output_dir)),
+            'canvas_height': int(canvas_h),
+            'canvas_width': int(canvas_w),
+            'n_tiles': len(tile_results),
+        })
+        if verbose:
+            print(f'  wrote {plane_name} ({canvas_h}x{canvas_w}, '
+                  f'{len(tile_results)} tiles)')
+    manifest = {
+        'base': index['base'],
+        'timepoints': index['timepoints'],
+        'z_planes': index['z_planes'],
+        'tiles': index['tiles'],
+        'n_planes_written': len(written),
+        'pool_stride': pooled.get('stride'),
+        'n_files_pooled': pooled.get('n_files_pooled'),
+        'consensus_taus_ns': [float(x) for x in pooled['global_summary']['taus_ns']],
+        'pooled_peak_bin': int(pooled['pooled_peak']),
+        'tile_positions': [
+            {'s': p['s'], 'pixel_y': p['pixel_y'], 'pixel_x': p['pixel_x']}
+            for p in tile_positions],
+        'planes': written,
+    }
+    manifest_path = output_dir / f'{roi_base}_series_index.json'
+    with open(manifest_path, 'w') as f:
+        json.dump(manifest, f, indent=2)
+    if verbose:
+        print(f"\n{'='*60}")
+        print(f'  {len(written)}/{len(planes)} planes written to {output_dir}')
+        print(f'  Manifest: {manifest_path}')
+        print(f"{'='*60}")
+    return manifest
+
 def fit_flim_tiles(
     xlif_path,
     ptu_dir,
@@ -621,6 +846,8 @@ def fit_flim_tiles(
     verbose=True,
     progress_callback=None,
     cancel_event=None,
+    tile_positions=None,
+    pooled=None,
 ):
     from .reader import PTUFile
     from ...FLIM.fitters import fit_summed, fit_per_pixel
@@ -634,7 +861,9 @@ def fit_flim_tiles(
         Cost_function, Optimizer, lm_restarts, n_workers,
         binning_factor,
     )
-    xlif_path = Path(xlif_path)
+    if xlif_path is None and tile_positions is None:
+        raise ValueError('fit_flim_tiles needs either xlif_path or tile_positions')
+    xlif_path = Path(xlif_path) if xlif_path is not None else None
     ptu_dir = Path(ptu_dir)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -676,12 +905,18 @@ def fit_flim_tiles(
         if verbose:
             print(f"  TVB background from: {_tvb_ptu_path} ({float(_tvb_bg_raw.sum()):,.0f} photons)")
     _fit_tvb = _tvb_bg_raw is not None
-    tile_positions = parse_tile_positions(xlif_path, ptu_basename)
-    pixel_size_m, _ = get_pixel_size(xlif_path, ptu_basename)
-    effective_pixel_size_m = pixel_size_m * binning
-    tile_positions, canvas_w, canvas_h = compute_tile_pixel_positions(
-        tile_positions, effective_pixel_size_m,
-        _peek_tile_width(ptu_dir, tile_positions, rotate_tiles) // binning)
+    if tile_positions is None:
+        tile_positions = parse_tile_positions(xlif_path, ptu_basename)
+    if 'pixel_x' in tile_positions[0] and 'pixel_y' in tile_positions[0]:
+        tile_w = _peek_tile_width(ptu_dir, tile_positions, rotate_tiles) // binning
+        canvas_w = max(t['pixel_x'] for t in tile_positions) + tile_w
+        canvas_h = max(t['pixel_y'] for t in tile_positions) + tile_w
+    else:
+        pixel_size_m, _ = get_pixel_size(xlif_path, ptu_basename)
+        effective_pixel_size_m = pixel_size_m * binning
+        tile_positions, canvas_w, canvas_h = compute_tile_pixel_positions(
+            tile_positions, effective_pixel_size_m,
+            _peek_tile_width(ptu_dir, tile_positions, rotate_tiles) // binning)
     if verbose:
         print(f"\n{'='*60}")
         print(f"  PER-TILE FLIM FITTING - POOLED MACHINE IRF")
@@ -692,76 +927,102 @@ def fit_flim_tiles(
         print(f"  Canvas:      {canvas_h} × {canvas_w} px")
         print(f"  Machine IRF: {mach_path}  (peak bin {pi_machine})\n")
     total_steps = 2 * len(tile_positions)
-    if verbose:
-        print('Pass 1: accumulating pooled decay (summed_decay only)...')
-    tile_meta = []
-    pooled_decay = None
-    n_bins_ref = None
-    tcspc_ref = None
-    for i, t in enumerate(tqdm(tile_positions,
-                                desc='  Pass 1', disable=True)):
-        if cancel_event is not None and cancel_event.is_set():
-            break
-        if progress_callback is not None:
-            progress_callback(i, total_steps)
-        ptu_path = ptu_dir / t['file']
-        if not ptu_path.exists():
-            continue
-        ptu = PTUFile(str(ptu_path), verbose=False)
-        decay = ptu.summed_decay()
-        n_bins = ptu.n_bins
-        tcspc = ptu.tcspc_res
-        if intensity_thr is not None:
-            stack_p1 = ptu.raw_pixel_stack(channel=ptu.photon_channel)
-            px_int = stack_p1.sum(axis=-1)
-            mask_p1 = px_int >= intensity_thr
-            stack_p1[~mask_p1] = 0
-            decay = stack_p1.sum(axis=(0, 1))
-            del stack_p1, px_int, mask_p1
-        if pooled_decay is None:
-            pooled_decay = decay.copy()
-            n_bins_ref = n_bins
-            tcspc_ref = tcspc
-        else:
-            if n_bins > n_bins_ref:
-                pooled_decay = np.pad(pooled_decay, (0, n_bins - n_bins_ref))
+    if pooled is not None:
+        pooled_decay = pooled['pooled_decay']
+        pooled_irf = pooled['pooled_irf']
+        pooled_peak = pooled['pooled_peak']
+        n_bins_ref = pooled['n_bins']
+        tcspc_ref = pooled['tcspc']
+        global_popt = pooled['global_popt']
+        global_summary = pooled['global_summary']
+        tile_meta = []
+        for t in tile_positions:
+            ptu_path = ptu_dir / t['file']
+            if not ptu_path.exists():
+                continue
+            ptu = PTUFile(str(ptu_path), verbose=False)
+            tile_meta.append({
+                't': t,
+                'n_bins': ptu.n_bins,
+                'tcspc': ptu.tcspc_res,
+                'peak_bin': pooled_peak,
+            })
+        if not tile_meta:
+            raise RuntimeError('No tiles found - check PTU_DIR and PTU_BASENAME.')
+        if verbose:
+            print(f'Pass 1 skipped: reusing pooled fit '
+                  f'({len(tile_meta)} tiles, peak bin {pooled_peak})')
+    else:
+        if verbose:
+            print('Pass 1: accumulating pooled decay (summed_decay only)...')
+        tile_meta = []
+        pooled_decay = None
+        n_bins_ref = None
+        tcspc_ref = None
+        for i, t in enumerate(tqdm(tile_positions,
+                                    desc='  Pass 1', disable=True)):
+            if cancel_event is not None and cancel_event.is_set():
+                break
+            if progress_callback is not None:
+                progress_callback(i, total_steps)
+            ptu_path = ptu_dir / t['file']
+            if not ptu_path.exists():
+                continue
+            ptu = PTUFile(str(ptu_path), verbose=False)
+            decay = ptu.summed_decay()
+            n_bins = ptu.n_bins
+            tcspc = ptu.tcspc_res
+            if intensity_thr is not None:
+                stack_p1 = ptu.raw_pixel_stack(channel=ptu.photon_channel)
+                px_int = stack_p1.sum(axis=-1)
+                mask_p1 = px_int >= intensity_thr
+                stack_p1[~mask_p1] = 0
+                decay = stack_p1.sum(axis=(0, 1))
+                del stack_p1, px_int, mask_p1
+            if pooled_decay is None:
+                pooled_decay = decay.copy()
                 n_bins_ref = n_bins
-            if len(decay) < len(pooled_decay):
-                decay = np.pad(decay, (0, len(pooled_decay) - len(decay)))
-            pooled_decay[:len(decay)] += decay[:len(pooled_decay)]
-        tile_meta.append({
-            't':        t,
-            'n_bins':   n_bins,
-            'tcspc':    tcspc,
-            'peak_bin': int(np.argmax(decay)),
-        })
-    if pooled_decay is None:
-        raise RuntimeError('No tiles found - check PTU_DIR and PTU_BASENAME.')
-    pooled_peak = int(np.argmax(pooled_decay))
-    pooled_irf = _get_tile_irf(machine_irf, pi_machine, pooled_peak, n_bins_ref)
-    if verbose:
-        print(f"\n  Pooled: {len(tile_meta)} tiles  "
-              f"{pooled_decay.sum():,.0f} photons  peak bin {pooled_peak}")
-        print('\n  Running consensus fit_summed on pooled decay...')
-    _tvb_pooled = (tvb_from_decay(_tvb_bg_raw, n_bins_ref,
-                                  src_tcspc_res=_tvb_bg_res, dst_tcspc_res=tcspc_ref)
-                   if _fit_tvb else None)
-    global_popt, global_summary = fit_summed(
-        pooled_decay, tcspc_ref, n_bins_ref, pooled_irf,
-        has_tail = has_tail,
-        fit_bg = fit_bg,
-        fit_sigma = fit_sigma,
-        n_exp = n_exp_,
-        tau_min_ns = tau_min_ns,
-        tau_max_ns = tau_max_ns,
-        optimizer = optimizer,
-        cost_function = cost_fn,
-        n_restarts = restarts,
-        workers = workers,
-        sigma_max = sigma_max,
-        tvb_profile = _tvb_pooled,
-        fit_tvb = _fit_tvb,
-    )
+                tcspc_ref = tcspc
+            else:
+                if n_bins > n_bins_ref:
+                    pooled_decay = np.pad(pooled_decay, (0, n_bins - n_bins_ref))
+                    n_bins_ref = n_bins
+                if len(decay) < len(pooled_decay):
+                    decay = np.pad(decay, (0, len(pooled_decay) - len(decay)))
+                pooled_decay[:len(decay)] += decay[:len(pooled_decay)]
+            tile_meta.append({
+                't':        t,
+                'n_bins':   n_bins,
+                'tcspc':    tcspc,
+                'peak_bin': int(np.argmax(decay)),
+            })
+        if pooled_decay is None:
+            raise RuntimeError('No tiles found - check PTU_DIR and PTU_BASENAME.')
+        pooled_peak = int(np.argmax(pooled_decay))
+        pooled_irf = _get_tile_irf(machine_irf, pi_machine, pooled_peak, n_bins_ref)
+        if verbose:
+            print(f"\n  Pooled: {len(tile_meta)} tiles  "
+                  f"{pooled_decay.sum():,.0f} photons  peak bin {pooled_peak}")
+            print('\n  Running consensus fit_summed on pooled decay...')
+        _tvb_pooled = (tvb_from_decay(_tvb_bg_raw, n_bins_ref,
+                                      src_tcspc_res=_tvb_bg_res, dst_tcspc_res=tcspc_ref)
+                       if _fit_tvb else None)
+        global_popt, global_summary = fit_summed(
+            pooled_decay, tcspc_ref, n_bins_ref, pooled_irf,
+            has_tail = has_tail,
+            fit_bg = fit_bg,
+            fit_sigma = fit_sigma,
+            n_exp = n_exp_,
+            tau_min_ns = tau_min_ns,
+            tau_max_ns = tau_max_ns,
+            optimizer = optimizer,
+            cost_function = cost_fn,
+            n_restarts = restarts,
+            workers = workers,
+            sigma_max = sigma_max,
+            tvb_profile = _tvb_pooled,
+            fit_tvb = _fit_tvb,
+        )
     consensus_taus_ns = global_summary['taus_ns']
     if verbose:
         print(f"\n  Consensus τ = {[f'{t:.3f}' for t in consensus_taus_ns]} ns")

--- a/flimkit_tests/tests/test_gui_modes.py
+++ b/flimkit_tests/tests/test_gui_modes.py
@@ -146,3 +146,81 @@ def test_irf_widget_browse_accepts_csv_exports():
 
     filetypes = browse.call_args.args[2]
     assert any('*.csv' in pattern for _, pattern in filetypes)
+
+
+def test_series_fit_pipeline_toggles_series_controls(app):
+    app._switch_form('stitch')
+    app.sv_pipeline.set('series_fit')
+    app._pipeline_changed()
+    assert app._series_frame.winfo_manager()
+    assert app._xlif_optional_note.winfo_manager()
+    assert app._btn_st.cget('text') == '▶  Run Series Fit'
+
+def test_series_controls_hidden_for_other_pipelines(app):
+    app._switch_form('stitch')
+    for mode in ('series_fit', 'stitch_only', 'tile_fit', 'stitch_fit'):
+        app.sv_pipeline.set(mode)
+        app._pipeline_changed()
+    assert not app._series_frame.winfo_manager()
+    assert not app._xlif_optional_note.winfo_manager()
+
+def test_series_fit_args_derive_roi_from_ptu_dir(app, tmp_path):
+    app._switch_form('stitch')
+    app.sv_pipeline.set('series_fit')
+    app.sv_xlif.set('')
+    app.sv_ptu_dir.set(str(tmp_path / 'my series'))
+    app.sv_out_st.set(str(tmp_path / 'out'))
+    a = app._controller.stitch_args()
+    assert a.ptu_basename is None
+    assert Path(a.output_dir).name == 'my_series'
+
+def test_non_series_args_still_derive_roi_from_xlif(app, tmp_path):
+    app._switch_form('stitch')
+    app.sv_pipeline.set('tile_fit')
+    app.sv_xlif.set(str(tmp_path / 'R 2.xlif'))
+    app.sv_ptu_dir.set(str(tmp_path))
+    app.sv_out_st.set(str(tmp_path / 'out'))
+    a = app._controller.stitch_args()
+    assert a.ptu_basename == 'R 2'
+    assert Path(a.output_dir).name == 'R_2'
+
+
+def _series_planes():
+    return [{'t': 1, 'z': 1, 'name': 'R_t1_z1', 'dir': 'R_t1_z1'},
+            {'t': 1, 'z': 2, 'name': 'R_t1_z2', 'dir': 'R_t1_z2'},
+            {'t': 2, 'z': 1, 'name': 'R_t2_z1', 'dir': 'R_t2_z1'}]
+
+def test_display_series_shows_slider_over_all_planes(app, tmp_path):
+    fov = app._fov_preview
+    fov.display_series(_series_planes(), tmp_path)
+    assert fov._zbar.winfo_manager()
+    assert float(fov._z_slider.cget('to')) == 2.0
+    assert fov._z_label.get().startswith('t1 z1')
+    assert '(1/3)' in fov._z_label.get()
+
+def test_series_slider_moves_between_planes(app, tmp_path):
+    fov = app._fov_preview
+    fov.display_series(_series_planes(), tmp_path)
+    fov._on_z_slider('2')
+    assert fov._z_i == 2
+    assert fov._z_label.get().startswith('t2 z1')
+    assert fov._series is not None
+
+def test_series_slider_clamps_out_of_range(app, tmp_path):
+    fov = app._fov_preview
+    fov.display_series(_series_planes(), tmp_path)
+    fov._on_z_slider('99')
+    assert fov._z_i == 2
+
+def test_display_series_with_no_planes_hides_bar(app, tmp_path):
+    fov = app._fov_preview
+    fov.display_series([], tmp_path)
+    assert not fov._zbar.winfo_manager()
+    assert fov._series is None
+
+def test_loading_a_single_fov_clears_the_series_bar(app, tmp_path):
+    fov = app._fov_preview
+    fov.display_series(_series_planes(), tmp_path)
+    fov._hide_zstack()
+    assert fov._series is None
+    assert not fov._zbar.winfo_manager()

--- a/flimkit_tests/tests/test_ptu_series.py
+++ b/flimkit_tests/tests/test_ptu_series.py
@@ -1,0 +1,172 @@
+import numpy as np
+import pytest
+
+from flimkit.formats.PTU.series import (
+    parse_series_name,
+    index_ptu_series,
+    describe_series,
+    register_tile_pair,
+    recover_tile_positions,
+    plane_tile_positions,
+)
+
+pytestmark = pytest.mark.unit
+
+def _touch(directory, names):
+    for n in names:
+        (directory / n).write_bytes(b'')
+
+def test_parse_full_series_name():
+    p = parse_series_name('R 1 (4)_t100_s2_z3.ptu')
+    assert p['base'] == 'R 1 (4)'
+    assert (p['t'], p['s'], p['z']) == (100, 2, 3)
+    assert p['has_t'] and p['has_z']
+
+def test_parse_tile_only_name_defaults_to_one():
+    p = parse_series_name('R 2_s7.ptu')
+    assert p['base'] == 'R 2'
+    assert (p['t'], p['s'], p['z']) == (1, 7, 1)
+    assert not p['has_t'] and not p['has_z']
+
+def test_parse_rejects_non_series_name():
+    assert parse_series_name('calibration.ptu') is None
+
+def test_parse_shares_grammar_with_batch_fit():
+    from flimkit.utils.batch_fit import parse_timelapse_filename
+    for name in ('R 1 (4)_t100_s2_z3.ptu', 'R 1_t3_z2.ptu', 'R 1_t7.ptu'):
+        region, t, s, z = parse_timelapse_filename(name)
+        p = parse_series_name(name)
+        assert (p['base'], p['t'], p['s'], p['z']) == (region, t, s or 1, z or 1)
+
+def test_index_rejects_single_position_series(tmp_path):
+    _touch(tmp_path, [f'R 1_t{t}_z1.ptu' for t in (1, 2, 3)])
+    with pytest.raises(RuntimeError, match='nothing to stitch'):
+        index_ptu_series(tmp_path)
+
+def test_index_groups_by_plane(tmp_path):
+    _touch(tmp_path, [f'R 1_t{t}_s{s}_z{z}.ptu'
+                      for t in (1, 2) for s in (1, 2) for z in (1, 2, 3)])
+    idx = index_ptu_series(tmp_path)
+    assert idx['base'] == 'R 1'
+    assert idx['timepoints'] == [1, 2]
+    assert idx['z_planes'] == [1, 2, 3]
+    assert idx['tiles'] == [1, 2]
+    assert idx['n_files'] == 12
+    assert len(idx['planes']) == 6
+    assert [e['s'] for e in idx['planes'][(2, 3)]] == [1, 2]
+    assert not idx['is_ragged']
+
+def test_index_handles_plain_tile_series(tmp_path):
+    _touch(tmp_path, [f'R 2_s{s}.ptu' for s in range(1, 5)])
+    idx = index_ptu_series(tmp_path)
+    assert idx['timepoints'] == [1]
+    assert idx['z_planes'] == [1]
+    assert idx['tiles'] == [1, 2, 3, 4]
+    assert not idx['has_t'] and not idx['has_z']
+
+def test_index_flags_ragged_series(tmp_path):
+    _touch(tmp_path, ['R 1_t1_s1_z1.ptu', 'R 1_t1_s2_z1.ptu', 'R 1_t2_s1_z1.ptu'])
+    assert index_ptu_series(tmp_path)['is_ragged']
+
+def test_index_rejects_mixed_basenames(tmp_path):
+    _touch(tmp_path, ['R 1_s1.ptu', 'R 2_s1.ptu'])
+    with pytest.raises(RuntimeError, match='Multiple series'):
+        index_ptu_series(tmp_path)
+
+def test_index_selects_requested_basename(tmp_path):
+    _touch(tmp_path, ['R 1_s1.ptu', 'R 1_s2.ptu', 'R 2_s1.ptu'])
+    idx = index_ptu_series(tmp_path, ptu_basename='R 1')
+    assert idx['tiles'] == [1, 2]
+
+def test_index_raises_when_empty(tmp_path):
+    _touch(tmp_path, ['notes.txt', 'calibration.ptu'])
+    with pytest.raises(RuntimeError, match='No PTU files'):
+        index_ptu_series(tmp_path)
+
+def test_describe_series_reports_counts(tmp_path):
+    _touch(tmp_path, [f'R 1_t{t}_s{s}_z1.ptu' for t in (1, 2, 3) for s in (1, 2)])
+    text = describe_series(index_ptu_series(tmp_path))
+    assert '3 timepoint(s)' in text and '2 tile(s)' in text
+
+def _mosaic(shape=(160, 140), seed=0):
+    rng = np.random.default_rng(seed)
+    scene = rng.gamma(2.0, 40.0, size=shape)
+    for _ in range(25):
+        y, x = rng.integers(8, shape[0] - 8), rng.integers(8, shape[1] - 8)
+        scene[y - 6:y + 6, x - 6:x + 6] += rng.uniform(200, 900)
+    return scene
+
+def test_register_tile_pair_recovers_known_vertical_shift():
+    scene = _mosaic()
+    a = scene[0:100, 0:120]
+    b = scene[60:160, 0:120]
+    reg = register_tile_pair(a, b)
+    assert (reg['dy'], reg['dx']) == (60, 0)
+    assert reg['correlation'] > 0.9
+    assert reg['overlap_px'] == 40 * 120
+
+def test_register_tile_pair_recovers_diagonal_shift():
+    scene = _mosaic(seed=3)
+    a = scene[0:100, 0:100]
+    b = scene[55:155, 18:118]
+    reg = register_tile_pair(a, b)
+    assert (reg['dy'], reg['dx']) == (55, 18)
+    assert reg['correlation'] > 0.9
+
+def test_register_tile_pair_rejects_mismatched_shapes():
+    with pytest.raises(ValueError, match='Tile shapes differ'):
+        register_tile_pair(np.zeros((10, 10)), np.zeros((10, 12)))
+
+def test_recover_tile_positions_chains_three_tiles():
+    scene = _mosaic(shape=(260, 140), seed=5)
+    tiles = [scene[0:100, 0:120], scene[70:170, 0:120], scene[140:240, 0:120]]
+    positions, pairs = recover_tile_positions(tiles)
+    assert [p['pixel_y'] for p in positions] == [0, 70, 140]
+    assert [p['pixel_x'] for p in positions] == [0, 0, 0]
+    assert len(pairs) == 2
+
+def test_recover_tile_positions_normalises_to_origin():
+    scene = _mosaic(shape=(260, 140), seed=7)
+    tiles = [scene[140:240, 0:120], scene[70:170, 0:120]]
+    positions, _ = recover_tile_positions(tiles)
+    assert min(p['pixel_y'] for p in positions) == 0
+    assert [p['pixel_y'] for p in positions] == [70, 0]
+
+def test_recover_tile_positions_rejects_uncorrelated_tiles():
+    rng = np.random.default_rng(11)
+    tiles = [rng.gamma(2.0, 40.0, (100, 100)), rng.gamma(2.0, 40.0, (100, 100))]
+    with pytest.raises(RuntimeError, match='registration too weak'):
+        recover_tile_positions(tiles, min_correlation=0.9)
+
+def test_recover_tile_positions_needs_two_tiles():
+    with pytest.raises(ValueError, match='at least two tiles'):
+        recover_tile_positions([np.zeros((10, 10))])
+
+def test_plane_tile_positions_maps_reference_onto_plane():
+    reference = [
+        {'s': 1, 'pixel_y': 0, 'pixel_x': 0, 'file': 'R 1_t1_s1_z1.ptu'},
+        {'s': 2, 'pixel_y': 54, 'pixel_x': 3, 'file': 'R 1_t1_s2_z1.ptu'},
+    ]
+    entries = [{'s': 2, 'file': 'R 1_t9_s2_z2.ptu'}, {'s': 1, 'file': 'R 1_t9_s1_z2.ptu'}]
+    out = plane_tile_positions(reference, entries)
+    assert [p['file'] for p in out] == ['R 1_t9_s1_z2.ptu', 'R 1_t9_s2_z2.ptu']
+    assert [p['pixel_y'] for p in out] == [0, 54]
+
+def test_plane_tile_positions_reports_missing_tile():
+    reference = [{'s': 1, 'pixel_y': 0, 'pixel_x': 0, 'file': 'a.ptu'}]
+    with pytest.raises(RuntimeError, match='no recovered position'):
+        plane_tile_positions(reference, [{'s': 2, 'file': 'b.ptu'}])
+
+def test_fit_flim_tiles_requires_positions_or_metadata(tmp_path):
+    from types import SimpleNamespace
+    from flimkit.formats.PTU.stitch import fit_flim_tiles
+    with pytest.raises(ValueError, match='xlif_path or tile_positions'):
+        fit_flim_tiles(None, tmp_path, tmp_path, SimpleNamespace(nexp=2))
+
+def test_fit_flim_series_rejects_ragged_series(tmp_path):
+    from types import SimpleNamespace
+    from flimkit.formats.PTU.stitch import fit_flim_series
+    _touch(tmp_path, ['R 1_t1_s1_z1.ptu', 'R 1_t1_s2_z1.ptu', 'R 1_t2_s1_z1.ptu'])
+    with pytest.raises(RuntimeError, match='different tile count'):
+        fit_flim_series(tmp_path, tmp_path / 'out', SimpleNamespace(nexp=2),
+                        verbose=False)


### PR DESCRIPTION
Addresses #21. The existing timelapse and z-stack batch fits treat each _sY position as an independent field of view. When those positions are overlapping tiles of one larger region that is not what you want, which is what the issue reports. This stitches them into one canvas per (t, z) plane.

Leica writes one PTU per (timepoint, tile, z) with the indices in the filename, so the series structure is read directly rather than inferred from the _s{N} flattening order. flimkit/utils/batch_fit.py already parsed that convention for the batch fits, so parse_series_name delegates to parse_timelapse_filename and only adds a fallback for the plain <base>_s<N>.ptu form the existing stitcher uses. A single-position stack is rejected with a pointer to the batch fits, which handle that case.

Tile positions are recovered from the images, so no .lif or .xlif is needed. FFT phase correlation was tried first and does not work here: on the 20260326 set it returns a 0.0084 peak against a 0.0082 runner-up, which is noise. register_tile_pair instead maximises Pearson r over the overlap on log1p intensity, keeping the top N coarse candidates before refining, because a coarse grid lands off a sharp peak and small overlaps otherwise win spuriously.

fit_flim_series loops planes, reusing one pooled decay and one consensus tau set across the whole series so amplitudes stay comparable between timepoints, and writes one output directory per (t, z) plus a manifest. Pass 1 is subsampled by pool_stride since the pooled histogram only needs photon statistics. fit_flim_tiles takes optional tile_positions and pooled arguments; both default to None and the existing xlif path is unchanged.

UI: a fourth Stitch pipeline, "Multidimensional series". The XLIF field is not required in this mode, so stitch_args derives the ROI name from the PTU directory and leaves ptu_basename as None. The FOV preview gains display_series, which drives the existing z-stack slider over every fitted plane, loading each from disk as you drag.

Currently unverified against actual data, but feature request from issue #21.