### PR TITLE
Stabilize multistart fitting with log-scaled parameters

### DIFF
--- a/flimkit/FLIM/fitters.py
+++ b/flimkit/FLIM/fitters.py
@@ -140,6 +140,21 @@ def fit_summed(decay, tcspc_res, n_bins, irf_prompt,
             r[m < n] *= -1                   
             return r
     if optimizer == 'lm_multistart':
+        n_log = n_exp
+        lo_scaled = np.asarray(lo, dtype=float).copy()
+        hi_scaled = np.asarray(hi, dtype=float).copy()
+        lo_scaled[:n_log] = np.log10(lo_scaled[:n_log])
+        hi_scaled[:n_log] = np.log10(hi_scaled[:n_log])
+        def to_scaled(params):
+            scaled = np.asarray(params, dtype=float).copy()
+            scaled[:n_log] = np.log10(scaled[:n_log])
+            return scaled
+        def from_scaled(params):
+            linear = np.asarray(params, dtype=float).copy()
+            linear[:n_log] = 10.0 ** linear[:n_log]
+            return linear
+        def residuals_scaled(params):
+            return residuals(from_scaled(params))
         rng = np.random.default_rng(42)
         best_res = None
         best_cost = np.inf
@@ -151,7 +166,8 @@ def fit_summed(decay, tcspc_res, n_bins, irf_prompt,
                           has_tail, fit_bg, fit_sigma, bg_init,
                           tau_override=tau_ov, fit_tvb=fit_tvb, tvb_init=tvb_init)
             try:
-                res = least_squares(residuals, p0, bounds=(lo, hi), method='trf',
+                res = least_squares(residuals_scaled, to_scaled(p0),
+                                    bounds=(lo_scaled, hi_scaled), method='trf',
                                     max_nfev=50000,
                                     ftol=1e-13, xtol=1e-13, gtol=1e-13)
             except Exception as exc:
@@ -166,7 +182,7 @@ def fit_summed(decay, tcspc_res, n_bins, irf_prompt,
                 print(f"    Restart {i:2d} ({tag}): cost={res.cost:.4e}")
         if best_res is None:
             raise RuntimeError('All restarts failed.')
-        popt_work = best_res.x
+        popt_work = from_scaled(best_res.x)
         message = best_res.message
     elif optimizer == 'de':
         print(f"  Differential evolution: popsize={de_popsize}, "

--- a/flimkit_tests/tests/test_optimizer_scaling.py
+++ b/flimkit_tests/tests/test_optimizer_scaling.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from flimkit import synth
+from flimkit.FLIM.fitters import fit_summed
+
+
+def test_multistart_recovers_high_count_biexponential_truth():
+    expected, irf, _truth = synth.build_decay(
+        tau_ns=[3.0, 0.8],
+        amps=[0.6, 0.4],
+        n_bins=2000,
+        tcspc_res_ns=0.025,
+        irf_fwhm_ns=0.15,
+        irf_center_ns=2.0,
+        n_photons=1e6,
+        background_frac=0.0,
+    )
+    decay = np.random.default_rng(0).poisson(expected).astype(float)
+
+    _params, summary = fit_summed(
+        decay=decay,
+        tcspc_res=0.025e-9,
+        n_bins=2000,
+        irf_prompt=irf,
+        has_tail=False,
+        fit_bg=True,
+        fit_sigma=False,
+        n_exp=2,
+        tau_min_ns=0.145,
+        tau_max_ns=45.0,
+        optimizer='lm_multistart',
+        n_restarts=8,
+        cost_function='poisson',
+        irf_shift_bins=2,
+    )
+
+    fitted = np.asarray(summary['taus_ns'])
+    truth = np.asarray([3.0, 0.8])
+    relative_error = np.abs(fitted - truth) / truth
+    termination = summary['optimizer_msg']
+
+    assert relative_error.max() < 0.05, (
+        f'multistart failed to recover biexponential truth: '
+        f'taus={fitted.tolist()}, relative_error={relative_error.tolist()}, '
+        f'termination={termination}'
+    )


### PR DESCRIPTION
## Summary

- Optimize positive lifetimes and amplitudes in `log10` coordinates inside `lm_multistart`.
- Convert the fitted parameters back to the existing linear units before creating FLIMKit results.
- Add a deterministic regression test for high-count biexponential lifetime recovery.

## Problem

The `lm_multistart` path passes lifetimes in seconds, amplitudes in counts, and nuisance parameters in their native units to bounded SciPy TRF. These values can span many orders of magnitude. In controlled high-count biexponential simulations, every restart could stop through `xtol` while still returning a poor physical fit.

This change keeps the same reconvolution model, Poisson residuals, bounds, restart strategy, and public parameter format. It changes only the internal optimizer coordinates for lifetimes and amplitudes.

## Controlled synthetic results

| Case | Maximum lifetime error | Poisson deviance / DoF | Generating-model deviance / DoF |
|---|---:|---:|---:|
| Biexponential, 10⁶ photons | 59.3% → 1.31% | 2.212 → 0.857 | 0.857 |
| Biexponential, 10⁷ photons | 77.8% → 0.45% | 19.555 → 0.979 | 0.980 |

Here, Poisson deviance is the standard likelihood-ratio deviance for Poisson counts. Dividing it by the residual degrees of freedom gives the values shown above. The corrected fits are close to the values obtained from the exact generating model.

The default differential-evolution path is unchanged.

## Tests

A new deterministic test generates a `3.0 ns + 0.8 ns` biexponential decay with $10^6$ photons and requires both recovered lifetimes to be within 5% of truth.

```text
pytest -q flimkit_tests/tests/test_optimizer_scaling.py
1 passed
```

Full local suite:

```text
600 passed, 26 skipped, 2 failed
```

The two failures are existing order-dependent CPU/GPU TVB parity failures. They reproduce unchanged on the untouched upstream revision under the same test order and pass when run independently.

## Scope

- No change to the fluorescence model or IRF reconvolution.
- No change to the default differential-evolution optimizer.
- No change to user-visible parameter units or output fields.
- No change to the number or selection of restart points.
