### PR TITLE
Add expected-contribution-normalized chi-square diagnostics

### DIFF
--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -746,6 +746,23 @@ Pixel values outside the range are clamped to the boundary, not zeroed.
 | `poisson` | Poisson deviance (C-statistic). Recommended |
 | `chi2` | Neyman chi-squared (legacy)  |
 
+### Goodness-of-fit outputs
+
+The existing `reduced_chi2_pearson`, `reduced_chi2_tail_pearson`, and per-pixel
+`chi2_r` fields are retained for compatibility with historical Leica LAS X
+comparisons. Their one-count model floor means they are not generally expected
+to equal one for sparse decays.
+
+`calibrated_chi2_pearson`, `calibrated_chi2_tail_pearson`, and the per-pixel
+`calibrated_chi2` map divide the same residual sum by its expected contribution
+under a fixed Poisson model:
+
+$$Q_{\mathrm{cal}} = \frac{\sum_i (Y_i-m_i)^2/\max(m_i,1)}{\sum_i \min(m_i,1)}.$$
+
+The fixed-model expectation is one. Parameter fitting and data-selected windows
+can introduce a smaller additional shift, so this diagnostic is not a classical
+chi-square p-value.
+
 ---
 
 ## Module Reference

--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -746,23 +746,6 @@ Pixel values outside the range are clamped to the boundary, not zeroed.
 | `poisson` | Poisson deviance (C-statistic). Recommended |
 | `chi2` | Neyman chi-squared (legacy)  |
 
-### Goodness-of-fit outputs
-
-The existing `reduced_chi2_pearson`, `reduced_chi2_tail_pearson`, and per-pixel
-`chi2_r` fields are retained for compatibility with historical Leica LAS X
-comparisons. Their one-count model floor means they are not generally expected
-to equal one for sparse decays.
-
-`calibrated_chi2_pearson`, `calibrated_chi2_tail_pearson`, and the per-pixel
-`calibrated_chi2` map divide the same residual sum by its expected contribution
-under a fixed Poisson model:
-
-$$Q_{\mathrm{cal}} = \frac{\sum_i (Y_i-m_i)^2/\max(m_i,1)}{\sum_i \min(m_i,1)}.$$
-
-The fixed-model expectation is one. Parameter fitting and data-selected windows
-can introduce a smaller additional shift, so this diagnostic is not a classical
-chi-square p-value.
-
 ---
 
 ## Module Reference

--- a/flimkit/FLIM/assemble.py
+++ b/flimkit/FLIM/assemble.py
@@ -12,7 +12,7 @@ def assemble_tile_maps(
 ) -> Dict[str, np.ndarray]:
     H, W = canvas_height, canvas_width
 
-    keys_scalar = ['tau_mean_amp', 'tau_mean_int', 'chi2']
+    keys_scalar = ['tau_mean_amp', 'tau_mean_int', 'chi2', 'calibrated_chi2']
     keys_tau    = [f'tau{k}' for k in range(1, n_exp + 1)]
     keys_amp    = [f'a{k}'   for k in range(1, n_exp + 1)]
     keys_all    = keys_scalar + keys_tau + keys_amp

--- a/flimkit/FLIM/assemble.py
+++ b/flimkit/FLIM/assemble.py
@@ -12,7 +12,7 @@ def assemble_tile_maps(
 ) -> Dict[str, np.ndarray]:
     H, W = canvas_height, canvas_width
 
-    keys_scalar = ['tau_mean_amp', 'tau_mean_int', 'chi2', 'calibrated_chi2']
+    keys_scalar = ['tau_mean_amp', 'tau_mean_int', 'chi2', 'calibrated_chi2_r']
     keys_tau    = [f'tau{k}' for k in range(1, n_exp + 1)]
     keys_amp    = [f'a{k}'   for k in range(1, n_exp + 1)]
     keys_all    = keys_scalar + keys_tau + keys_amp

--- a/flimkit/FLIM/batch.py
+++ b/flimkit/FLIM/batch.py
@@ -192,7 +192,7 @@ def fit_timelapse(ptu_dir, output_dir, args,
                 intensity = pixel_maps.get('intensity', pixel_stack.sum(axis=2))
                 np.save(str(pos_dir / 'intensity.npy'), intensity.astype(np.float32))
                 for map_name in ('alpha_1', 'alpha_2', 'alpha_3', 'tau_mean_amp',
-                                 'tau_mean_int', 'chi2_r', 'calibrated_chi2'):
+                                 'tau_mean_int', 'chi2_r', 'calibrated_chi2_r'):
                     if pixel_maps.get(map_name) is not None:
                         np.save(str(pos_dir / f'{map_name}.npy'),
                                 pixel_maps[map_name].astype(np.float32))
@@ -516,7 +516,7 @@ def fit_zstack(ptu_dir, output_dir, args,
             intensity = pixel_maps.get('intensity', pixel_stack.sum(axis=2))
             np.save(str(slice_dir / 'intensity.npy'), intensity.astype(np.float32))
             for map_name in ('alpha_1', 'alpha_2', 'alpha_3', 'tau_mean_amp',
-                             'tau_mean_int', 'chi2_r', 'calibrated_chi2'):
+                             'tau_mean_int', 'chi2_r', 'calibrated_chi2_r'):
                 if pixel_maps.get(map_name) is not None:
                     np.save(str(slice_dir / f'{map_name}.npy'),
                             pixel_maps[map_name].astype(np.float32))

--- a/flimkit/FLIM/batch.py
+++ b/flimkit/FLIM/batch.py
@@ -142,6 +142,10 @@ def fit_timelapse(ptu_dir, output_dir, args,
             'positions': all_s,
             'estimate_irf': getattr(args, 'estimate_irf', 'gaussian'),
             'user_supplied_tau': use_supplied,
+            'calibrated_chi2_pearson': global_summary.get(
+                'calibrated_chi2_pearson'),
+            'calibrated_chi2_tail_pearson': global_summary.get(
+                'calibrated_chi2_tail_pearson'),
         })
         print(f'\n[3] Per-frame per-position fitting  (α free, τ locked)…')
         per_pos_series = {s: {} for s in all_s}
@@ -188,7 +192,7 @@ def fit_timelapse(ptu_dir, output_dir, args,
                 intensity = pixel_maps.get('intensity', pixel_stack.sum(axis=2))
                 np.save(str(pos_dir / 'intensity.npy'), intensity.astype(np.float32))
                 for map_name in ('alpha_1', 'alpha_2', 'alpha_3', 'tau_mean_amp',
-                                 'tau_mean_int', 'chi2_r'):
+                                 'tau_mean_int', 'chi2_r', 'calibrated_chi2'):
                     if pixel_maps.get(map_name) is not None:
                         np.save(str(pos_dir / f'{map_name}.npy'),
                                 pixel_maps[map_name].astype(np.float32))
@@ -446,6 +450,10 @@ def fit_zstack(ptu_dir, output_dir, args,
             'z_slices': sorted(zslices),
             'estimate_irf': getattr(args, 'estimate_irf', 'gaussian'),
             'user_supplied_tau': use_supplied,
+            'calibrated_chi2_pearson': global_summary.get(
+                'calibrated_chi2_pearson'),
+            'calibrated_chi2_tail_pearson': global_summary.get(
+                'calibrated_chi2_tail_pearson'),
         })
         n_ref = min(len(pooled_decay), n_bins)
         ref_time_ns = (np.arange(n_ref) + 0.5) * tcspc_res * 1e9
@@ -461,6 +469,12 @@ def fit_zstack(ptu_dir, output_dir, args,
             taus_ns=np.asarray(list(taus_ns), dtype=np.float64),
             reduced_chi2_tail=np.asarray(
                 [global_summary.get('reduced_chi2_tail', float('nan'))], dtype=np.float64),
+            calibrated_chi2_pearson=np.asarray(
+                [global_summary.get('calibrated_chi2_pearson', float('nan'))],
+                dtype=np.float64),
+            calibrated_chi2_tail_pearson=np.asarray(
+                [global_summary.get('calibrated_chi2_tail_pearson', float('nan'))],
+                dtype=np.float64),
         )
         print(f'\n[3] Per-slice per-pixel fitting  (α free, τ locked)…')
         z_series = {}
@@ -502,7 +516,7 @@ def fit_zstack(ptu_dir, output_dir, args,
             intensity = pixel_maps.get('intensity', pixel_stack.sum(axis=2))
             np.save(str(slice_dir / 'intensity.npy'), intensity.astype(np.float32))
             for map_name in ('alpha_1', 'alpha_2', 'alpha_3', 'tau_mean_amp',
-                             'tau_mean_int', 'chi2_r'):
+                             'tau_mean_int', 'chi2_r', 'calibrated_chi2'):
                 if pixel_maps.get(map_name) is not None:
                     np.save(str(slice_dir / f'{map_name}.npy'),
                             pixel_maps[map_name].astype(np.float32))

--- a/flimkit/FLIM/fit_tools.py
+++ b/flimkit/FLIM/fit_tools.py
@@ -4,7 +4,6 @@ from scipy.optimize import curve_fit
 
 
 def calibrated_chi2(data, model, axis=None):
-    """Return the expected-contribution-normalized model chi-square."""
     data_arr, model_arr = np.broadcast_arrays(
         np.asarray(data, dtype=float), np.asarray(model, dtype=float))
     valid = np.all(

--- a/flimkit/FLIM/fit_tools.py
+++ b/flimkit/FLIM/fit_tools.py
@@ -2,6 +2,27 @@ import numpy as np
 from scipy.ndimage import gaussian_filter1d
 from scipy.optimize import curve_fit
 
+
+def calibrated_chi2(data, model, axis=None):
+    """Return the expected-contribution-normalized model chi-square."""
+    data_arr, model_arr = np.broadcast_arrays(
+        np.asarray(data, dtype=float), np.asarray(model, dtype=float))
+    valid = np.all(
+        np.isfinite(data_arr) & (data_arr >= 0.0)
+        & np.isfinite(model_arr) & (model_arr >= 0.0),
+        axis=axis)
+    with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
+        numerator = np.sum(
+            (data_arr - model_arr) ** 2 / np.maximum(model_arr, 1.0), axis=axis)
+        expected = np.sum(np.minimum(model_arr, 1.0), axis=axis)
+    if np.ndim(expected) == 0:
+        return float(numerator / expected) if valid and expected > 0 else np.nan
+    result = np.full(np.shape(expected), np.nan, dtype=float)
+    return np.divide(
+        numerator, expected, out=result,
+        where=valid & (expected > 0) & np.isfinite(numerator))
+
+
 def coates_pileup_correction(decay: np.ndarray, n_sync: int):
     m = np.asarray(decay, dtype=float)
     n_s = float(n_sync or 0.0)

--- a/flimkit/FLIM/fitters.py
+++ b/flimkit/FLIM/fitters.py
@@ -8,7 +8,8 @@ from scipy.stats.distributions import chi2 as chi2_dist
 from ..FLIM.irf_tools import build_full_irf
 from ..FLIM.fit_tools import (estimate_bg, find_fit_start, find_fit_end, _build_bounds,
                               _pack_p0, coates_pileup_correction, bins_from_ns, build_fit_idx,
-                              find_tail_fit_start, _build_bounds_tail, _pack_p0_tail)
+                              find_tail_fit_start, _build_bounds_tail, _pack_p0_tail,
+                              calibrated_chi2)
 from ..FLIM.models import (reconvolution_model, _DECost, _DECostLogTau,
                            _DECostPoisson, _DECostPoissonLogTau,
                            dist_reconvolution_model, build_dist_basis_grid,
@@ -279,6 +280,7 @@ def _make_summary(popt, decay, tcspc_res, n_bins, irf_prompt,
     sigma_p = np.sqrt(np.maximum(m_win, 1.0))
     chi2_p = float(np.sum(((d_win - m_win) / sigma_p)**2))
     rchi2_p = chi2_p / dof
+    calibrated_chi2_p = calibrated_chi2(d_win, m_win)
     peak_bin_loc = int(fit_idx[np.argmax(decay[fit_idx])])
     tail_start = peak_bin_loc + max(1, int(0.05 * (fit_end - peak_bin_loc)))
     tail_idx = fit_idx[fit_idx >= tail_start]
@@ -291,6 +293,7 @@ def _make_summary(popt, decay, tcspc_res, n_bins, irf_prompt,
     sp_tail = np.sqrt(np.maximum(m_tail, 1.0))
     chi2_tail_p = float(np.sum(((d_tail - m_tail) / sp_tail)**2))
     rchi2_tail_p = chi2_tail_p / dof_tail
+    calibrated_chi2_tail_p = calibrated_chi2(d_tail, m_tail)
     amp_sum = amps.sum() if amps.sum() > 0 else 1.0
     fracs = amps / amp_sum
     tau_amp = float(np.dot(fracs, taus))
@@ -313,6 +316,8 @@ def _make_summary(popt, decay, tcspc_res, n_bins, irf_prompt,
         chi2_pearson = chi2_p,
         reduced_chi2_pearson = rchi2_p,
         reduced_chi2_tail_pearson = rchi2_tail_p,
+        calibrated_chi2_pearson = calibrated_chi2_p,
+        calibrated_chi2_tail_pearson = calibrated_chi2_tail_p,
         tail_start_bin = tail_start,
         p_val = p_val,
         dof = dof,
@@ -526,6 +531,7 @@ def _make_summary_tail(popt, decay, tcspc_res, n_bins,
     sigma_p = np.sqrt(np.maximum(m_win, 1.0))
     chi2_p = float(np.sum(((d_win - m_win) / sigma_p)**2))
     rchi2_p = chi2_p / dof
+    calibrated_chi2_p = calibrated_chi2(d_win, m_win)
     amp_sum = amps.sum() if amps.sum() > 0 else 1.0
     fracs = amps / amp_sum
     tau_amp = float(np.dot(fracs, taus))
@@ -553,6 +559,8 @@ def _make_summary_tail(popt, decay, tcspc_res, n_bins,
         chi2_pearson = chi2_p,
         reduced_chi2_pearson = rchi2_p,
         reduced_chi2_tail_pearson = rchi2_p,
+        calibrated_chi2_pearson = calibrated_chi2_p,
+        calibrated_chi2_tail_pearson = calibrated_chi2_p,
         tail_start_bin = fit_start,
         p_val = p_val,
         dof = dof,
@@ -686,6 +694,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
         tau_mean_int = np.full((ny, nx), np.nan),
         tau_mean_amp = np.full((ny, nx), np.nan),
         chi2_r = np.full((ny, nx), np.nan),
+        calibrated_chi2 = np.full((ny, nx), np.nan),
     )
     for i in range(n_exp):
         maps[f"alpha_{i+1}"] = np.full((ny, nx), np.nan)
@@ -756,6 +765,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                     resid = dvf_f[k] - model_px
                     chi2_px = float(np.sum(resid ** 2 / np.maximum(model_px, 1.0)))
                     maps['chi2_r'][yi, xi] = chi2_px / max(len(fit_idx) - 2, 1)
+                    maps['calibrated_chi2'][yi, xi] = calibrated_chi2(dvf_f[k], model_px)
                     fitted += 1
                 continue
             dv = decay_row[valid_xi] 
@@ -792,6 +802,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                 resid = dv[k][fit_idx] - model_px
                 chi2_px = float(np.sum(resid ** 2 / np.maximum(model_px, 1.0)))
                 maps['chi2_r'][yi, xi] = chi2_px / max(len(fit_idx) - 2, 1)
+                maps['calibrated_chi2'][yi, xi] = calibrated_chi2(dv[k][fit_idx], model_px)
                 fitted += 1
     elif not free_tau:
         for yi in tqdm(range(ny), desc='  Per-pixel rows', disable=True):
@@ -834,6 +845,8 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_int'][yi, xi] = tau_int
                 maps['tau_mean_amp'][yi, xi] = tau_amp
                 maps['chi2_r'][yi, xi] = chi2_px / dof_px
+                maps['calibrated_chi2'][yi, xi] = calibrated_chi2(
+                    decay_px[fit_idx], model_px)
                 for i in range(n_exp):
                     maps[f"alpha_{i+1}"][yi, xi] = amps_px[i]
                     maps[f"frac_{i+1}"][yi, xi] = fracs_px[i]
@@ -937,6 +950,8 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_int'][yi, xi] = tau_int
                 maps['tau_mean_amp'][yi, xi] = tau_amp
                 maps['chi2_r'][yi, xi] = chi2_px / dof_px
+                maps['calibrated_chi2'][yi, xi] = calibrated_chi2(
+                    decay_px[fit_idx], model_sol[fit_idx])
                 for i in range(n_exp):
                     maps[f"tau_{i+1}"][yi, xi] = taus_ns[i]
                     maps[f"alpha_{i+1}"][yi, xi] = amps_sol[i]
@@ -1136,6 +1151,7 @@ def _make_summary_dist(popt, decay, tcspc_res, n_bins, irf_prompt,
     sigma_p = np.sqrt(np.maximum(m_win, 1.0))
     chi2_p = float(np.sum(((d_win - m_win) / sigma_p) ** 2))
     rchi2_p = chi2_p / dof
+    calibrated_chi2_p = calibrated_chi2(d_win, m_win)
     peak_bin_loc = int(fit_idx[np.argmax(decay[fit_idx])])
     tail_start = peak_bin_loc + max(1, int(0.05 * (fit_end - peak_bin_loc)))
     tail_idx = fit_idx[fit_idx >= tail_start]
@@ -1148,6 +1164,7 @@ def _make_summary_dist(popt, decay, tcspc_res, n_bins, irf_prompt,
     sp_tail = np.sqrt(np.maximum(m_tail, 1.0))
     chi2_tail_p = float(np.sum(((d_tail - m_tail) / sp_tail) ** 2))
     rchi2_tail_p = chi2_tail_p / dof_tail
+    calibrated_chi2_tail_p = calibrated_chi2(d_tail, m_tail)
     resid = (decay - model) / np.sqrt(np.maximum(model, 1.0))
     from ..FLIM.models import _alpha_gaussian, _alpha_lorentzian, _N_QUAD
     alpha_fn = _alpha_gaussian if dist_type == 'gaussian' else _alpha_lorentzian
@@ -1195,6 +1212,8 @@ def _make_summary_dist(popt, decay, tcspc_res, n_bins, irf_prompt,
         chi2_pearson = chi2_p,
         reduced_chi2_pearson = rchi2_p,
         reduced_chi2_tail_pearson = rchi2_tail_p,
+        calibrated_chi2_pearson = calibrated_chi2_p,
+        calibrated_chi2_tail_pearson = calibrated_chi2_tail_p,
         tail_start_bin = tail_start,
         dof = dof,
         fit_window_bins = (fit_start, fit_end),
@@ -1247,6 +1266,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
         tau_mean_amp = np.full((ny, nx), np.nan),
         tau_mean_int = np.full((ny, nx), np.nan),
         chi2_r = np.full((ny, nx), np.nan),
+        calibrated_chi2 = np.full((ny, nx), np.nan),
     )
     for i in range(n_components):
         maps[f"tau_center_{i+1}"] = np.full((ny, nx), np.nan)
@@ -1294,6 +1314,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
             w_v = param_pairs[best_g, 1]
             model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * B_arr[None, :] + bg_z[:, None]
             chi2_v = ((d_valid - model_v) ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+            chi2_cal_v = calibrated_chi2(d_valid, model_v, axis=1)
             for k, fi in enumerate(valid_idx):
                 if amp_v[k] <= 0:
                     continue
@@ -1305,6 +1326,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_amp'][yy, xx] = tau_v[k] * 1e9
                 maps['tau_mean_int'][yy, xx] = (tau_v[k] + w_v[k] ** 2 / max(tau_v[k], 1e-15)) * 1e9
                 maps['chi2_r'][yy, xx] = chi2_v[k]
+                maps['calibrated_chi2'][yy, xx] = chi2_cal_v[k]
                 maps['tvb_scale'][yy, xx] = tvb_v[k]
             return maps
         t0 = time.time()
@@ -1338,6 +1360,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_amp'][row_i, xi] = tau_amp_ns
                 maps['tau_mean_int'][row_i, xi] = tau_int_ns
                 maps['chi2_r'][row_i, xi] = chi2_px / max(n_bins - 3, 1)
+                maps['calibrated_chi2'][row_i, xi] = calibrated_chi2(d, model_px)
     else:
         from ..FLIM.fit_tools import estimate_bg as _ebg
         from concurrent.futures import ThreadPoolExecutor
@@ -1399,6 +1422,17 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
             tau_int_ns = float(np.dot(amp_s, tau_cs ** 2) / max(np.dot(amp_s, tau_cs), 1e-30)) * 1e9
             maps['tau_mean_amp'][yi, xi] = tau_amp_ns
             maps['tau_mean_int'][yi, xi] = tau_int_ns
+            d = flat[flat_idx].astype(np.float64)
+            bg = _ebg(d, int(np.argmax(d)))
+            full_p = np.concatenate([sol, [shift]])
+            if fit_sigma:
+                full_p = np.concatenate([full_p, [sigma]])
+            if fit_bg:
+                full_p = np.concatenate([full_p, [bg]])
+            model_px = dist_reconvolution_model(
+                full_p, tcspc_res, n_bins, irf_prompt,
+                n_components, dist_type, bg, False, False)
+            maps['calibrated_chi2'][yi, xi] = calibrated_chi2(d, model_px)
             for i in range(n_components):
                 maps[f"tau_center_{i+1}"][yi, xi] = tau_cs[i] * 1e9
                 maps[f"width_{i+1}"][yi, xi] = ws[i] * 1e9

--- a/flimkit/FLIM/fitters.py
+++ b/flimkit/FLIM/fitters.py
@@ -694,7 +694,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
         tau_mean_int = np.full((ny, nx), np.nan),
         tau_mean_amp = np.full((ny, nx), np.nan),
         chi2_r = np.full((ny, nx), np.nan),
-        calibrated_chi2 = np.full((ny, nx), np.nan),
+        calibrated_chi2_r = np.full((ny, nx), np.nan),
     )
     for i in range(n_exp):
         maps[f"alpha_{i+1}"] = np.full((ny, nx), np.nan)
@@ -765,7 +765,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                     resid = dvf_f[k] - model_px
                     chi2_px = float(np.sum(resid ** 2 / np.maximum(model_px, 1.0)))
                     maps['chi2_r'][yi, xi] = chi2_px / max(len(fit_idx) - 2, 1)
-                    maps['calibrated_chi2'][yi, xi] = calibrated_chi2(dvf_f[k], model_px)
+                    maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(dvf_f[k], model_px)
                     fitted += 1
                 continue
             dv = decay_row[valid_xi] 
@@ -802,7 +802,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                 resid = dv[k][fit_idx] - model_px
                 chi2_px = float(np.sum(resid ** 2 / np.maximum(model_px, 1.0)))
                 maps['chi2_r'][yi, xi] = chi2_px / max(len(fit_idx) - 2, 1)
-                maps['calibrated_chi2'][yi, xi] = calibrated_chi2(dv[k][fit_idx], model_px)
+                maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(dv[k][fit_idx], model_px)
                 fitted += 1
     elif not free_tau:
         for yi in tqdm(range(ny), desc='  Per-pixel rows', disable=True):
@@ -845,7 +845,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_int'][yi, xi] = tau_int
                 maps['tau_mean_amp'][yi, xi] = tau_amp
                 maps['chi2_r'][yi, xi] = chi2_px / dof_px
-                maps['calibrated_chi2'][yi, xi] = calibrated_chi2(
+                maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(
                     decay_px[fit_idx], model_px)
                 for i in range(n_exp):
                     maps[f"alpha_{i+1}"][yi, xi] = amps_px[i]
@@ -950,7 +950,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_int'][yi, xi] = tau_int
                 maps['tau_mean_amp'][yi, xi] = tau_amp
                 maps['chi2_r'][yi, xi] = chi2_px / dof_px
-                maps['calibrated_chi2'][yi, xi] = calibrated_chi2(
+                maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(
                     decay_px[fit_idx], model_sol[fit_idx])
                 for i in range(n_exp):
                     maps[f"tau_{i+1}"][yi, xi] = taus_ns[i]
@@ -1266,7 +1266,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
         tau_mean_amp = np.full((ny, nx), np.nan),
         tau_mean_int = np.full((ny, nx), np.nan),
         chi2_r = np.full((ny, nx), np.nan),
-        calibrated_chi2 = np.full((ny, nx), np.nan),
+        calibrated_chi2_r = np.full((ny, nx), np.nan),
     )
     for i in range(n_components):
         maps[f"tau_center_{i+1}"] = np.full((ny, nx), np.nan)
@@ -1326,7 +1326,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_amp'][yy, xx] = tau_v[k] * 1e9
                 maps['tau_mean_int'][yy, xx] = (tau_v[k] + w_v[k] ** 2 / max(tau_v[k], 1e-15)) * 1e9
                 maps['chi2_r'][yy, xx] = chi2_v[k]
-                maps['calibrated_chi2'][yy, xx] = chi2_cal_v[k]
+                maps['calibrated_chi2_r'][yy, xx] = chi2_cal_v[k]
                 maps['tvb_scale'][yy, xx] = tvb_v[k]
             return maps
         t0 = time.time()
@@ -1360,7 +1360,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 maps['tau_mean_amp'][row_i, xi] = tau_amp_ns
                 maps['tau_mean_int'][row_i, xi] = tau_int_ns
                 maps['chi2_r'][row_i, xi] = chi2_px / max(n_bins - 3, 1)
-                maps['calibrated_chi2'][row_i, xi] = calibrated_chi2(d, model_px)
+                maps['calibrated_chi2_r'][row_i, xi] = calibrated_chi2(d, model_px)
     else:
         from ..FLIM.fit_tools import estimate_bg as _ebg
         from concurrent.futures import ThreadPoolExecutor
@@ -1432,7 +1432,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
             model_px = dist_reconvolution_model(
                 full_p, tcspc_res, n_bins, irf_prompt,
                 n_components, dist_type, bg, False, False)
-            maps['calibrated_chi2'][yi, xi] = calibrated_chi2(d, model_px)
+            maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(d, model_px)
             for i in range(n_components):
                 maps[f"tau_center_{i+1}"][yi, xi] = tau_cs[i] * 1e9
                 maps[f"width_{i+1}"][yi, xi] = ws[i] * 1e9

--- a/flimkit/GPU/_base.py
+++ b/flimkit/GPU/_base.py
@@ -2,6 +2,7 @@ import multiprocessing
 import numpy as np
 from concurrent.futures import ThreadPoolExecutor
 from scipy.optimize import least_squares
+from ..FLIM.fit_tools import calibrated_chi2
 from ..FLIM.models import reconvolution_model
 
 class GPUBackend:
@@ -71,6 +72,7 @@ class _BackendMixin:
             tau_mean_int = np.full((ny, nx), np.nan),
             tau_mean_amp = np.full((ny, nx), np.nan),
             chi2_r       = np.full((ny, nx), np.nan),
+            calibrated_chi2 = np.full((ny, nx), np.nan),
         )
         for i in range(n_exp):
             maps[f"alpha_{i+1}"] = np.full((ny, nx), np.nan)
@@ -120,6 +122,8 @@ class _BackendMixin:
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]]       = chi2[good] / dof
+        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = calibrated_chi2(
+            decay_valid[good], model[good], axis=1)
         for i in range(n_exp):
             maps[f"alpha_{i+1}"][yi_arr[good], xi_arr[good]] = amps[good, i]
             maps[f"frac_{i+1}"][yi_arr[good], xi_arr[good]]  = fracs[good, i]
@@ -168,6 +172,8 @@ class _BackendMixin:
         maps['alpha_1'][yi_arr[good], xi_arr[good]]      = amp_v[good]
         maps['frac_1'][yi_arr[good], xi_arr[good]]       = 1.0
         maps['chi2_r'][yi_arr[good], xi_arr[good]]       = chi2[good]
+        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = calibrated_chi2(
+            decay_valid[good], model[good], axis=1)
         if tvb is not None:
             maps.setdefault('tvb_scale', np.full((ny, nx), np.nan))
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb[good]
@@ -179,6 +185,7 @@ class _BackendMixin:
         taus_s,
         amps,
         chi2_r,
+        calibrated_values,
         ny, nx,
         n_exp,
         tvb=None,
@@ -202,6 +209,7 @@ class _BackendMixin:
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]]       = chi2_r[good]
+        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = calibrated_values[good]
         for i in range(n_exp):
             maps[f"tau_{i+1}"][yi_arr[good], xi_arr[good]]   = taus_ns[good, i]
             maps[f"alpha_{i+1}"][yi_arr[good], xi_arr[good]] = amps[good, i]
@@ -274,6 +282,7 @@ class _BackendMixin:
         taus_out  = np.zeros((B, n_exp), dtype=np.float32)
         amps_out  = np.zeros((B, n_exp), dtype=np.float32)
         chi2r_out = np.full(B, np.nan, dtype=np.float64)
+        chi2c_out = np.full(B, np.nan, dtype=np.float64)
         model_out = np.zeros((B, n_bins), dtype=np.float32)
         tvb_out   = np.zeros(B, dtype=np.float32)
         valid_b   = np.zeros(B, dtype=bool)
@@ -309,6 +318,7 @@ class _BackendMixin:
             model_out[b] = model_b.astype(np.float32)
             tvb_out[b]   = tvb_b
             chi2r_out[b] = chi2_b / dof
+            chi2c_out[b] = calibrated_chi2(raw_valid[b], model_b)
             valid_b[b]   = True
 
-        return taus_out, amps_out, chi2r_out, model_out, valid_b, tvb_out
+        return taus_out, amps_out, chi2r_out, chi2c_out, model_out, valid_b, tvb_out

--- a/flimkit/GPU/_base.py
+++ b/flimkit/GPU/_base.py
@@ -72,7 +72,7 @@ class _BackendMixin:
             tau_mean_int = np.full((ny, nx), np.nan),
             tau_mean_amp = np.full((ny, nx), np.nan),
             chi2_r       = np.full((ny, nx), np.nan),
-            calibrated_chi2 = np.full((ny, nx), np.nan),
+            calibrated_chi2_r = np.full((ny, nx), np.nan),
         )
         for i in range(n_exp):
             maps[f"alpha_{i+1}"] = np.full((ny, nx), np.nan)
@@ -122,7 +122,7 @@ class _BackendMixin:
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]]       = chi2[good] / dof
-        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = calibrated_chi2(
+        maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = calibrated_chi2(
             decay_valid[good], model[good], axis=1)
         for i in range(n_exp):
             maps[f"alpha_{i+1}"][yi_arr[good], xi_arr[good]] = amps[good, i]
@@ -172,7 +172,7 @@ class _BackendMixin:
         maps['alpha_1'][yi_arr[good], xi_arr[good]]      = amp_v[good]
         maps['frac_1'][yi_arr[good], xi_arr[good]]       = 1.0
         maps['chi2_r'][yi_arr[good], xi_arr[good]]       = chi2[good]
-        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = calibrated_chi2(
+        maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = calibrated_chi2(
             decay_valid[good], model[good], axis=1)
         if tvb is not None:
             maps.setdefault('tvb_scale', np.full((ny, nx), np.nan))
@@ -209,7 +209,7 @@ class _BackendMixin:
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]]       = chi2_r[good]
-        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = calibrated_values[good]
+        maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = calibrated_values[good]
         for i in range(n_exp):
             maps[f"tau_{i+1}"][yi_arr[good], xi_arr[good]]   = taus_ns[good, i]
             maps[f"alpha_{i+1}"][yi_arr[good], xi_arr[good]] = amps[good, i]

--- a/flimkit/GPU/mlx_backend.py
+++ b/flimkit/GPU/mlx_backend.py
@@ -1,6 +1,6 @@
 import numpy as np
 from flimkit.GPU._base import _BackendMixin
-from flimkit.FLIM.fit_tools import estimate_bg, coates_pileup_correction
+from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
 
 class MLXBackend(_BackendMixin):
 
@@ -201,6 +201,7 @@ class MLXBackend(_BackendMixin):
             tau_mean_amp = np.full((ny, nx), np.nan),
             tau_mean_int = np.full((ny, nx), np.nan),
             chi2_r = np.full((ny, nx), np.nan),
+            calibrated_chi2 = np.full((ny, nx), np.nan),
             tau_center_1 = np.full((ny, nx), np.nan),
             width_1 = np.full((ny, nx), np.nan),
             alpha_1 = np.full((ny, nx), np.nan),
@@ -238,6 +239,7 @@ class MLXBackend(_BackendMixin):
             model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * B_arr[None, :] + bg_z[:, None]
             resid_v = d_valid.astype(np.float64) - model_v
             chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+            chi2_cal_v = calibrated_chi2(d_valid, model_v, axis=1)
             yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
             maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
             maps['width_1'][yi_arr[good], xi_arr[good]] = w_v[good] * 1e9
@@ -246,6 +248,7 @@ class MLXBackend(_BackendMixin):
             maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
             maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
             maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
+            maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb_v[good]
             return maps
         bg_flat = self._estimate_bg_batch(flat, valid_mask)
@@ -271,6 +274,7 @@ class MLXBackend(_BackendMixin):
         model_v = amp_v[:, None] * basis_best + bg_flat[valid_idx, None]
         resid_v = dc_valid.astype(np.float64) - model_v
         chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+        chi2_cal_v = calibrated_chi2(flat[valid_idx], model_v, axis=1)
         yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
         maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['width_1'][yi_arr[good], xi_arr[good]] = w_v[good] * 1e9
@@ -279,6 +283,7 @@ class MLXBackend(_BackendMixin):
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
+        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
         return maps
 
 
@@ -331,7 +336,7 @@ class MLXBackend(_BackendMixin):
         raw_valid = flat[valid_idx].astype(np.float32)
         bg_valid = bg_flat[valid_idx].astype(np.float32)
         B = len(valid_idx)
-        taus_out, amps_out, chi2r_out, _, valid_b, tvb_out = self._scipy_parallel_free_tau_fit(
+        taus_out, amps_out, chi2r_out, chi2c_out, _, valid_b, tvb_out = self._scipy_parallel_free_tau_fit(
             raw_valid, bg_valid, irf_array, tcspc_res,
             taus_init, tau_min_s, tau_max_s, n_exp, n_bins,
             tvb_profile=tvb_profile, fit_tvb=fit_tvb,
@@ -339,7 +344,7 @@ class MLXBackend(_BackendMixin):
         self._scatter_free_tau(
             maps, valid_idx=valid_idx[valid_b],
             taus_s=taus_out[valid_b], amps=amps_out[valid_b],
-            chi2_r=chi2r_out[valid_b],
+            chi2_r=chi2r_out[valid_b], calibrated_values=chi2c_out[valid_b],
             ny=ny, nx=nx, n_exp=n_exp,
             tvb=tvb_out[valid_b] if fit_tvb else None,
         )

--- a/flimkit/GPU/mlx_backend.py
+++ b/flimkit/GPU/mlx_backend.py
@@ -201,7 +201,7 @@ class MLXBackend(_BackendMixin):
             tau_mean_amp = np.full((ny, nx), np.nan),
             tau_mean_int = np.full((ny, nx), np.nan),
             chi2_r = np.full((ny, nx), np.nan),
-            calibrated_chi2 = np.full((ny, nx), np.nan),
+            calibrated_chi2_r = np.full((ny, nx), np.nan),
             tau_center_1 = np.full((ny, nx), np.nan),
             width_1 = np.full((ny, nx), np.nan),
             alpha_1 = np.full((ny, nx), np.nan),
@@ -248,7 +248,7 @@ class MLXBackend(_BackendMixin):
             maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
             maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
             maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
-            maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
+            maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb_v[good]
             return maps
         bg_flat = self._estimate_bg_batch(flat, valid_mask)
@@ -283,7 +283,7 @@ class MLXBackend(_BackendMixin):
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
-        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
+        maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
         return maps
 
 

--- a/flimkit/GPU/torch_backend.py
+++ b/flimkit/GPU/torch_backend.py
@@ -260,7 +260,7 @@ class TorchBackend(_BackendMixin):
             tau_mean_amp = np.full((ny, nx), np.nan),
             tau_mean_int = np.full((ny, nx), np.nan),
             chi2_r = np.full((ny, nx), np.nan),
-            calibrated_chi2 = np.full((ny, nx), np.nan),
+            calibrated_chi2_r = np.full((ny, nx), np.nan),
             tau_center_1 = np.full((ny, nx), np.nan),
             width_1 = np.full((ny, nx), np.nan),
             alpha_1 = np.full((ny, nx), np.nan),
@@ -305,7 +305,7 @@ class TorchBackend(_BackendMixin):
             maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
             maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
             maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
-            maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
+            maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb_v[good]
             return maps
         bg_flat = self._estimate_bg_batch(flat, valid_mask)
@@ -339,5 +339,5 @@ class TorchBackend(_BackendMixin):
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
-        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
+        maps['calibrated_chi2_r'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
         return maps

--- a/flimkit/GPU/torch_backend.py
+++ b/flimkit/GPU/torch_backend.py
@@ -1,6 +1,6 @@
 import numpy as np
 from flimkit.GPU._base import _BackendMixin
-from flimkit.FLIM.fit_tools import estimate_bg, coates_pileup_correction
+from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
 
 class TorchBackend(_BackendMixin):
 
@@ -220,7 +220,7 @@ class TorchBackend(_BackendMixin):
         raw_valid = flat[valid_idx].astype(np.float32)
         bg_valid  = bg_flat[valid_idx].astype(np.float32)
         B = len(valid_idx)
-        taus_out, amps_out, chi2r_out, _, valid_b, tvb_out = self._scipy_parallel_free_tau_fit(
+        taus_out, amps_out, chi2r_out, chi2c_out, _, valid_b, tvb_out = self._scipy_parallel_free_tau_fit(
             raw_valid, bg_valid, irf_array, tcspc_res,
             taus_init, tau_min_s, tau_max_s, n_exp, n_bins,
             tvb_profile=tvb_profile, fit_tvb=fit_tvb,
@@ -228,7 +228,7 @@ class TorchBackend(_BackendMixin):
         self._scatter_free_tau(
             maps, valid_idx=valid_idx[valid_b],
             taus_s=taus_out[valid_b], amps=amps_out[valid_b],
-            chi2_r=chi2r_out[valid_b],
+            chi2_r=chi2r_out[valid_b], calibrated_values=chi2c_out[valid_b],
             ny=ny, nx=nx, n_exp=n_exp,
             tvb=tvb_out[valid_b] if fit_tvb else None,
         )
@@ -260,6 +260,7 @@ class TorchBackend(_BackendMixin):
             tau_mean_amp = np.full((ny, nx), np.nan),
             tau_mean_int = np.full((ny, nx), np.nan),
             chi2_r = np.full((ny, nx), np.nan),
+            calibrated_chi2 = np.full((ny, nx), np.nan),
             tau_center_1 = np.full((ny, nx), np.nan),
             width_1 = np.full((ny, nx), np.nan),
             alpha_1 = np.full((ny, nx), np.nan),
@@ -295,6 +296,7 @@ class TorchBackend(_BackendMixin):
             model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * B_arr[None, :] + bg_z[:, None]
             resid_v = d_valid.astype(np.float64) - model_v
             chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+            chi2_cal_v = calibrated_chi2(d_valid, model_v, axis=1)
             yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
             maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
             maps['width_1'][yi_arr[good], xi_arr[good]] = w_v[good] * 1e9
@@ -303,6 +305,7 @@ class TorchBackend(_BackendMixin):
             maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
             maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
             maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
+            maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb_v[good]
             return maps
         bg_flat = self._estimate_bg_batch(flat, valid_mask)
@@ -327,6 +330,7 @@ class TorchBackend(_BackendMixin):
         model_v = amp_v[:, None] * basis_best + bg_flat[valid_idx, None]
         resid_v = dc_valid.astype(np.float64) - model_v
         chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+        chi2_cal_v = calibrated_chi2(flat[valid_idx], model_v, axis=1)
         yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
         maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['width_1'][yi_arr[good], xi_arr[good]] = w_v[good] * 1e9
@@ -335,4 +339,5 @@ class TorchBackend(_BackendMixin):
         maps['tau_mean_amp'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['tau_mean_int'][yi_arr[good], xi_arr[good]] = tau_int_ns[good]
         maps['chi2_r'][yi_arr[good], xi_arr[good]] = chi2_v[good]
+        maps['calibrated_chi2'][yi_arr[good], xi_arr[good]] = chi2_cal_v[good]
         return maps

--- a/flimkit/UI/flim_display.py
+++ b/flimkit/UI/flim_display.py
@@ -55,7 +55,7 @@ def load_zstack_display_slices(group_dir, ptu_dir=None, region=None):
             return np.load(str(p)) if p.exists() else None
         pixel_maps = {}
         for k in ('tau_mean_int', 'tau_mean_amp', 'alpha_1', 'alpha_2', 'alpha_3',
-                  'chi2_r', 'calibrated_chi2'):
+                  'chi2_r', 'calibrated_chi2_r'):
             m = _load(k)
             if m is not None:
                 pixel_maps[k] = m

--- a/flimkit/UI/flim_display.py
+++ b/flimkit/UI/flim_display.py
@@ -18,6 +18,8 @@ def load_zstack_display_slices(group_dir, ptu_dir=None, region=None):
     nexp = ref.get('nexp', len(taus_ns))
     ref_decay = ref_time = ref_model = ref_irf = None
     ref_chi2 = None
+    ref_calibrated = ref.get('calibrated_chi2_pearson')
+    ref_calibrated_tail = ref.get('calibrated_chi2_tail_pearson')
     npz_path = group_dir / 'reference_decay.npz'
     if npz_path.exists():
         try:
@@ -27,6 +29,10 @@ def load_zstack_display_slices(group_dir, ptu_dir=None, region=None):
                 ref_model = zf['model'] if zf['model'].size > 0 else None
                 ref_irf = zf['irf_prompt'] if zf['irf_prompt'].size > 0 else None
                 ref_chi2 = float(zf['reduced_chi2_tail'][0]) if zf['reduced_chi2_tail'].size > 0 else None
+                if ref_calibrated is None and 'calibrated_chi2_pearson' in zf:
+                    ref_calibrated = float(zf['calibrated_chi2_pearson'][0])
+                if ref_calibrated_tail is None and 'calibrated_chi2_tail_pearson' in zf:
+                    ref_calibrated_tail = float(zf['calibrated_chi2_tail_pearson'][0])
         except Exception:
             pass
     z_to_ptu = {}
@@ -48,7 +54,8 @@ def load_zstack_display_slices(group_dir, ptu_dir=None, region=None):
             p = slice_dir / f'{name}.npy'
             return np.load(str(p)) if p.exists() else None
         pixel_maps = {}
-        for k in ('tau_mean_int', 'tau_mean_amp', 'alpha_1', 'alpha_2', 'alpha_3', 'chi2_r'):
+        for k in ('tau_mean_int', 'tau_mean_amp', 'alpha_1', 'alpha_2', 'alpha_3',
+                  'chi2_r', 'calibrated_chi2'):
             m = _load(k)
             if m is not None:
                 pixel_maps[k] = m
@@ -57,6 +64,10 @@ def load_zstack_display_slices(group_dir, ptu_dir=None, region=None):
             global_summary['model'] = ref_model
         if ref_chi2 is not None and ref_chi2 == ref_chi2:
             global_summary['reduced_chi2_tail'] = ref_chi2
+        if ref_calibrated is not None and ref_calibrated == ref_calibrated:
+            global_summary['calibrated_chi2_pearson'] = ref_calibrated
+        if ref_calibrated_tail is not None and ref_calibrated_tail == ref_calibrated_tail:
+            global_summary['calibrated_chi2_tail_pearson'] = ref_calibrated_tail
         fit_result = {
             'pixel_maps': pixel_maps,
             'intensity': _load('intensity'),

--- a/flimkit/formats/PTU/stitch.py
+++ b/flimkit/formats/PTU/stitch.py
@@ -385,6 +385,8 @@ def _adapt_pixel_maps(pixel_maps, n_exp,
         'tau_mean_amp': pixel_maps['tau_mean_amp'],
         'chi2': pixel_maps['chi2_r'],
     }
+    if 'calibrated_chi2' in pixel_maps:
+        adapted['calibrated_chi2'] = pixel_maps['calibrated_chi2']
     ny, nx = pixel_maps['intensity'].shape
     for k in range(1, n_exp + 1):
         adapted[f'tau{k}'] = np.full((ny, nx), taus_ns[k - 1], dtype=np.float32)

--- a/flimkit/formats/PTU/stitch.py
+++ b/flimkit/formats/PTU/stitch.py
@@ -385,8 +385,8 @@ def _adapt_pixel_maps(pixel_maps, n_exp,
         'tau_mean_amp': pixel_maps['tau_mean_amp'],
         'chi2': pixel_maps['chi2_r'],
     }
-    if 'calibrated_chi2' in pixel_maps:
-        adapted['calibrated_chi2'] = pixel_maps['calibrated_chi2']
+    if 'calibrated_chi2_r' in pixel_maps:
+        adapted['calibrated_chi2_r'] = pixel_maps['calibrated_chi2_r']
     ny, nx = pixel_maps['intensity'].shape
     for k in range(1, n_exp + 1):
         adapted[f'tau{k}'] = np.full((ny, nx), taus_ns[k - 1], dtype=np.float32)

--- a/flimkit/interactive.py
+++ b/flimkit/interactive.py
@@ -1419,7 +1419,8 @@ def _run_tile_fit(args, progress_callback=None, cancel_event=None, progress_wind
     _consensus_summary = global_summary
     global_summary = derive_global_tau(canvas, n_exp=args.nexp)
     for _key in ('model', 'reduced_chi2', 'reduced_chi2_tail',
-                 'reduced_chi2_tail_pearson', 'reduced_chi2_pearson'):
+                 'reduced_chi2_tail_pearson', 'reduced_chi2_pearson',
+                 'calibrated_chi2_pearson', 'calibrated_chi2_tail_pearson'):
         if _key in _consensus_summary:
             global_summary[_key] = _consensus_summary[_key]
     n_px = global_summary.get('n_pixels_fitted', 0)

--- a/flimkit/utils/batch_fit.py
+++ b/flimkit/utils/batch_fit.py
@@ -18,7 +18,7 @@ from ..configs import (
 )
 
 _STACK_MAPS = ['intensity', 'tau_mean_amp', 'alpha_1', 'alpha_2',
-               'bound_fraction', 'chi2_r']
+               'bound_fraction', 'chi2_r', 'calibrated_chi2']
 
 _TL_FILENAME_RE = re.compile(
     r'^(?P<region>.+?)_t(?P<t>\d+)(?:_s(?P<s>\d+))?(?:_z(?P<z>\d+))?\.ptu$',

--- a/flimkit/utils/batch_fit.py
+++ b/flimkit/utils/batch_fit.py
@@ -18,7 +18,7 @@ from ..configs import (
 )
 
 _STACK_MAPS = ['intensity', 'tau_mean_amp', 'alpha_1', 'alpha_2',
-               'bound_fraction', 'chi2_r', 'calibrated_chi2']
+               'bound_fraction', 'chi2_r', 'calibrated_chi2_r']
 
 _TL_FILENAME_RE = re.compile(
     r'^(?P<region>.+?)_t(?P<t>\d+)(?:_s(?P<s>\d+))?(?:_z(?P<z>\d+))?\.ptu$',

--- a/flimkit_tests/tests/test_chi2_calibration.py
+++ b/flimkit_tests/tests/test_chi2_calibration.py
@@ -163,7 +163,7 @@ def test_per_pixel_cpu_adds_calibrated_map():
         tcspc_res, n_bins, False, irf_fft=np.fft.fft(irf))[0]
     fitted_model = amp * basis + bg
 
-    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+    assert maps['calibrated_chi2_r'][0, 0] == pytest.approx(
         calibrated_chi2(decay, fitted_model))
 
 
@@ -190,8 +190,8 @@ def test_available_gpu_backend_matches_cpu_calibrated_map():
         stack, tcspc_res, n_bins, irf, False, False, False,
         global_popt, 1, min_photons=1, use_gpu='auto', gpu_backend=backend)
 
-    assert gpu['calibrated_chi2'][0, 0] == pytest.approx(
-        cpu['calibrated_chi2'][0, 0], rel=1e-5)
+    assert gpu['calibrated_chi2_r'][0, 0] == pytest.approx(
+        cpu['calibrated_chi2_r'][0, 0], rel=1e-5)
 
 
 def test_backend_scatter_adds_calibrated_map():
@@ -209,7 +209,7 @@ def test_backend_scatter_adds_calibrated_map():
         maps, np.array([0]), np.array([2e-9]), amp, bg,
         data, basis, 1, 1, data.shape[1])
 
-    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+    assert maps['calibrated_chi2_r'][0, 0] == pytest.approx(
         calibrated_chi2(data[0], model[0]))
 
 
@@ -223,7 +223,7 @@ def test_backend_free_tau_scatter_keeps_calibrated_values():
         np.array([0.5]), np.array([1.25]), 1, 1, 1)
 
     assert maps['chi2_r'][0, 0] == pytest.approx(0.5)
-    assert maps['calibrated_chi2'][0, 0] == pytest.approx(1.25)
+    assert maps['calibrated_chi2_r'][0, 0] == pytest.approx(1.25)
 
 
 def test_per_pixel_distribution_adds_calibrated_map():
@@ -254,7 +254,7 @@ def test_per_pixel_distribution_adds_calibrated_map():
         np.array([tau, width, amp, 0.0]), tcspc_res, n_bins,
         irf, 1, 'gaussian', bg, False, False)
 
-    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+    assert maps['calibrated_chi2_r'][0, 0] == pytest.approx(
         calibrated_chi2(decay, fitted_model))
 
 
@@ -289,14 +289,14 @@ def test_per_pixel_multicomponent_distribution_adds_calibrated_map():
         fitted_popt, tcspc_res, n_bins, irf, 2, 'gaussian',
         bg, False, False)
 
-    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+    assert maps['calibrated_chi2_r'][0, 0] == pytest.approx(
         calibrated_chi2(decay, fitted_model))
 
 
 def test_batch_exports_include_calibrated_map():
     from flimkit.utils.batch_fit import _STACK_MAPS
 
-    assert 'calibrated_chi2' in _STACK_MAPS
+    assert 'calibrated_chi2_r' in _STACK_MAPS
 
 
 def test_stitch_adapter_keeps_calibrated_map():
@@ -306,12 +306,12 @@ def test_stitch_adapter_keeps_calibrated_map():
         'intensity': np.ones((1, 1)),
         'tau_mean_amp': np.ones((1, 1)),
         'chi2_r': np.ones((1, 1)),
-        'calibrated_chi2': np.full((1, 1), 1.25),
+        'calibrated_chi2_r': np.full((1, 1), 1.25),
     }
 
     adapted = _adapt_pixel_maps(pixel_maps, 1, np.array([2.0]))
 
-    assert adapted['calibrated_chi2'][0, 0] == pytest.approx(1.25)
+    assert adapted['calibrated_chi2_r'][0, 0] == pytest.approx(1.25)
 
 
 def test_assembled_canvas_keeps_calibrated_map():
@@ -320,7 +320,7 @@ def test_assembled_canvas_keeps_calibrated_map():
     pixel_maps = {
         'intensity': np.ones((1, 1)),
         'tau_mean_amp': np.ones((1, 1)),
-        'calibrated_chi2': np.full((1, 1), 1.25),
+        'calibrated_chi2_r': np.full((1, 1), 1.25),
         'tau1': np.full((1, 1), 2.0),
         'a1': np.ones((1, 1)),
     }
@@ -334,7 +334,7 @@ def test_assembled_canvas_keeps_calibrated_map():
 
     canvas = assemble_tile_maps(tile_results, 1, 1, 1)
 
-    assert canvas['calibrated_chi2'][0, 0] == pytest.approx(1.25)
+    assert canvas['calibrated_chi2_r'][0, 0] == pytest.approx(1.25)
 
 
 def test_zstack_display_restores_calibrated_summed_values(tmp_path):

--- a/flimkit_tests/tests/test_chi2_calibration.py
+++ b/flimkit_tests/tests/test_chi2_calibration.py
@@ -1,0 +1,359 @@
+import numpy as np
+import pytest
+
+from flimkit.FLIM.fit_tools import calibrated_chi2
+
+
+def test_calibrated_chi2_uses_expected_sparse_bin_contributions():
+    data = np.array([0.0, 1.0, 3.0, 8.0])
+    model = np.array([0.1, 0.5, 3.5, 8.0])
+    numerator = np.sum((data - model) ** 2 / np.maximum(model, 1.0))
+    expected = np.sum(np.minimum(model, 1.0))
+
+    assert calibrated_chi2(data, model) == pytest.approx(numerator / expected)
+
+
+def test_calibrated_chi2_supports_per_pixel_arrays():
+    data = np.array([[0.0, 1.0, 2.0], [1.0, 0.0, 4.0], [0.0, 0.0, 0.0]])
+    model = np.array([[0.2, 0.8, 2.0], [0.5, 0.1, 3.5], [0.0, 0.0, 0.0]])
+    numerator = np.sum((data - model) ** 2 / np.maximum(model, 1.0), axis=1)
+    expected = np.sum(np.minimum(model, 1.0), axis=1)
+    expected_result = np.array([numerator[0] / expected[0], numerator[1] / expected[1], np.nan])
+
+    np.testing.assert_allclose(
+        calibrated_chi2(data, model, axis=1), expected_result, equal_nan=True)
+
+
+def test_calibrated_chi2_matches_bin_average_for_dense_model():
+    data = np.array([2.0, 5.0, 8.0])
+    model = np.array([2.5, 4.0, 7.0])
+    numerator = np.sum((data - model) ** 2 / model)
+
+    assert calibrated_chi2(data, model) == pytest.approx(numerator / model.size)
+
+
+def test_calibrated_chi2_is_undefined_for_zero_model():
+    assert np.isnan(calibrated_chi2(np.zeros(4), np.zeros(4)))
+
+
+def test_calibrated_chi2_rejects_invalid_poisson_models():
+    data = np.array([1.0, 2.0])
+
+    assert np.isnan(calibrated_chi2(data, np.array([-0.2, 1.0])))
+    assert np.isnan(calibrated_chi2(data, np.array([np.nan, 1.0])))
+    assert np.isnan(calibrated_chi2(data, np.array([np.inf, 1.0])))
+    assert np.isnan(calibrated_chi2(np.array([-1.0, 2.0]), np.ones(2)))
+
+
+def test_calibrated_chi2_has_unit_mean_for_sparse_poisson_data():
+    rng = np.random.default_rng(42)
+    model = np.geomspace(0.01, 0.9, 128)
+    data = rng.poisson(model, size=(5000, model.size))
+
+    calibrated = calibrated_chi2(data, model, axis=1)
+    legacy = np.sum((data - model) ** 2 / np.maximum(model, 1.0), axis=1) / model.size
+
+    assert np.mean(calibrated) == pytest.approx(1.0, abs=0.02)
+    assert np.mean(legacy) < 0.3
+
+
+def test_summed_summary_adds_calibrated_full_and_tail_values():
+    from flimkit.FLIM.fitters import _make_summary
+    from flimkit.FLIM.models import reconvolution_model
+
+    n_bins = 128
+    tcspc_res = 0.1e-9
+    irf = np.zeros(n_bins)
+    irf[0] = 1.0
+    popt = np.array([2e-9, 20.0, 0.0])
+    model = reconvolution_model(
+        popt, tcspc_res, n_bins, irf, 1, 0.0, False, False, False)
+    data = np.random.default_rng(7).poisson(model)
+    fit_idx = np.arange(n_bins)
+
+    summary = _make_summary(
+        popt, data, tcspc_res, n_bins, irf, 1, 0.0,
+        False, False, False, fit_idx)
+    tail_idx = fit_idx[fit_idx >= summary['tail_start_bin']]
+    legacy_numerator = np.sum((data - model) ** 2 / np.maximum(model, 1.0))
+
+    assert summary['chi2_pearson'] == pytest.approx(legacy_numerator)
+    assert summary['reduced_chi2_pearson'] == pytest.approx(
+        legacy_numerator / (n_bins - len(popt)))
+    assert summary['calibrated_chi2_pearson'] == pytest.approx(
+        calibrated_chi2(data[fit_idx], model[fit_idx]))
+    assert summary['calibrated_chi2_tail_pearson'] == pytest.approx(
+        calibrated_chi2(data[tail_idx], model[tail_idx]))
+
+
+def test_tail_summary_adds_calibrated_value():
+    from flimkit.FLIM.fitters import _make_summary_tail
+    from flimkit.FLIM.models import tail_model
+
+    n_bins = 128
+    tcspc_res = 0.1e-9
+    popt = np.array([2e-9, 20.0])
+    model = tail_model(popt, tcspc_res, n_bins, 1, 0.0, False)
+    data = np.random.default_rng(8).poisson(model)
+    fit_idx = np.arange(n_bins)
+
+    summary = _make_summary_tail(
+        popt, data, tcspc_res, n_bins, 1, 0.0, False, fit_idx)
+    expected = calibrated_chi2(data, model)
+    legacy_numerator = np.sum((data - model) ** 2 / np.maximum(model, 1.0))
+
+    assert summary['chi2_pearson'] == pytest.approx(legacy_numerator)
+    assert summary['reduced_chi2_pearson'] == pytest.approx(
+        legacy_numerator / (n_bins - len(popt)))
+    assert summary['calibrated_chi2_pearson'] == pytest.approx(expected)
+    assert summary['calibrated_chi2_tail_pearson'] == pytest.approx(expected)
+
+
+def test_distribution_summary_adds_calibrated_full_and_tail_values():
+    from flimkit.FLIM.fitters import _make_summary_dist
+    from flimkit.FLIM.models import dist_reconvolution_model
+
+    n_bins = 128
+    tcspc_res = 0.1e-9
+    irf = np.zeros(n_bins)
+    irf[0] = 1.0
+    popt = np.array([2e-9, 0.3e-9, 20.0, 0.0])
+    model = dist_reconvolution_model(
+        popt, tcspc_res, n_bins, irf, 1, 'gaussian',
+        0.0, False, False)
+    data = np.random.default_rng(9).poisson(model)
+    fit_idx = np.arange(n_bins)
+
+    summary = _make_summary_dist(
+        popt, data, tcspc_res, n_bins, irf, 1, 'gaussian',
+        0.0, False, False, fit_idx)
+    tail_idx = fit_idx[fit_idx >= summary['tail_start_bin']]
+    legacy_numerator = np.sum((data - model) ** 2 / np.maximum(model, 1.0))
+
+    assert summary['chi2_pearson'] == pytest.approx(legacy_numerator)
+    assert summary['reduced_chi2_pearson'] == pytest.approx(
+        legacy_numerator / (n_bins - len(popt)))
+    assert summary['calibrated_chi2_pearson'] == pytest.approx(
+        calibrated_chi2(data[fit_idx], model[fit_idx]))
+    assert summary['calibrated_chi2_tail_pearson'] == pytest.approx(
+        calibrated_chi2(data[tail_idx], model[tail_idx]))
+
+
+def test_per_pixel_cpu_adds_calibrated_map():
+    from flimkit.FLIM.fit_tools import estimate_bg
+    from flimkit.FLIM.fitters import _basis_rows, fit_per_pixel
+
+    n_bins = 128
+    tcspc_res = 0.1e-9
+    irf = np.zeros(n_bins)
+    irf[0] = 1.0
+    model = 20.0 * np.exp(-np.arange(n_bins) * tcspc_res / 2e-9)
+    decay = np.random.default_rng(10).poisson(model).astype(float)
+    stack = decay[None, None, :]
+    global_popt = np.array([2e-9, 20.0, 0.0])
+
+    maps = fit_per_pixel(
+        stack, tcspc_res, n_bins, irf, False, False, False,
+        global_popt, 1, min_photons=1, use_gpu=False)
+    tau = maps['tau_1'][0, 0] * 1e-9
+    amp = maps['alpha_1'][0, 0]
+    bg = estimate_bg(decay, int(np.argmax(decay)))
+    basis = _basis_rows(
+        np.array([tau]), np.arange(n_bins) * tcspc_res,
+        tcspc_res, n_bins, False, irf_fft=np.fft.fft(irf))[0]
+    fitted_model = amp * basis + bg
+
+    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+        calibrated_chi2(decay, fitted_model))
+
+
+def test_available_gpu_backend_matches_cpu_calibrated_map():
+    from flimkit.FLIM.fitters import fit_per_pixel
+    from flimkit.GPU import get_backend
+
+    backend = get_backend()
+    if backend is None:
+        pytest.skip('no GPU backend available')
+    n_bins = 128
+    tcspc_res = 0.1e-9
+    irf = np.zeros(n_bins)
+    irf[0] = 1.0
+    model = 20.0 * np.exp(-np.arange(n_bins) * tcspc_res / 2e-9)
+    decay = np.random.default_rng(14).poisson(model).astype(float)
+    stack = decay[None, None, :]
+    global_popt = np.array([2e-9, 20.0, 0.0])
+
+    cpu = fit_per_pixel(
+        stack, tcspc_res, n_bins, irf, False, False, False,
+        global_popt, 1, min_photons=1, use_gpu=False)
+    gpu = fit_per_pixel(
+        stack, tcspc_res, n_bins, irf, False, False, False,
+        global_popt, 1, min_photons=1, use_gpu='auto', gpu_backend=backend)
+
+    assert gpu['calibrated_chi2'][0, 0] == pytest.approx(
+        cpu['calibrated_chi2'][0, 0], rel=1e-5)
+
+
+def test_backend_scatter_adds_calibrated_map():
+    from flimkit.GPU._base import _BackendMixin
+
+    data = np.array([[0.0, 1.0, 3.0, 2.0]])
+    basis = np.array([[1.0, 0.5, 0.25, 0.125]])
+    amp = np.array([2.0])
+    bg = np.array([0.1])
+    model = amp[:, None] * basis + bg[:, None]
+    maps = _BackendMixin._init_maps(
+        1, 1, 1, np.array([[data.sum()]]), np.array([2.0]), True)
+
+    _BackendMixin._scatter_1exp(
+        maps, np.array([0]), np.array([2e-9]), amp, bg,
+        data, basis, 1, 1, data.shape[1])
+
+    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+        calibrated_chi2(data[0], model[0]))
+
+
+def test_backend_free_tau_scatter_keeps_calibrated_values():
+    from flimkit.GPU._base import _BackendMixin
+
+    maps = _BackendMixin._init_maps(
+        1, 1, 1, np.array([[10.0]]), np.array([2.0]), True)
+    _BackendMixin._scatter_free_tau(
+        maps, np.array([0]), np.array([[2e-9]]), np.array([[3.0]]),
+        np.array([0.5]), np.array([1.25]), 1, 1, 1)
+
+    assert maps['chi2_r'][0, 0] == pytest.approx(0.5)
+    assert maps['calibrated_chi2'][0, 0] == pytest.approx(1.25)
+
+
+def test_per_pixel_distribution_adds_calibrated_map():
+    from flimkit.FLIM.fit_tools import estimate_bg
+    from flimkit.FLIM.fitters import fit_per_pixel_dist
+    from flimkit.FLIM.models import dist_reconvolution_model
+
+    n_bins = 128
+    tcspc_res = 0.1e-9
+    irf = np.zeros(n_bins)
+    irf[0] = 1.0
+    global_popt = np.array([2e-9, 0.3e-9, 20.0, 0.0])
+    model = dist_reconvolution_model(
+        global_popt, tcspc_res, n_bins, irf, 1, 'gaussian',
+        0.0, False, False)
+    decay = np.random.default_rng(11).poisson(model).astype(float)
+
+    maps = fit_per_pixel_dist(
+        decay[None, None, :], tcspc_res, n_bins, irf,
+        global_popt, 1, 'gaussian', fit_bg=False, fit_sigma=False,
+        min_photons=1, n_tau_grid=20, n_width_grid=15,
+        use_gpu=False)
+    tau = maps['tau_center_1'][0, 0] * 1e-9
+    width = maps['width_1'][0, 0] * 1e-9
+    amp = maps['alpha_1'][0, 0]
+    bg = estimate_bg(decay, int(np.argmax(decay)))
+    fitted_model = dist_reconvolution_model(
+        np.array([tau, width, amp, 0.0]), tcspc_res, n_bins,
+        irf, 1, 'gaussian', bg, False, False)
+
+    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+        calibrated_chi2(decay, fitted_model))
+
+
+def test_per_pixel_multicomponent_distribution_adds_calibrated_map():
+    from flimkit.FLIM.fit_tools import estimate_bg
+    from flimkit.FLIM.fitters import fit_per_pixel_dist
+    from flimkit.FLIM.models import dist_reconvolution_model
+
+    n_bins = 64
+    tcspc_res = 0.1e-9
+    irf = np.zeros(n_bins)
+    irf[0] = 1.0
+    global_popt = np.array([
+        0.8e-9, 2.5e-9, 0.15e-9, 0.4e-9, 30.0, 20.0, 0.0])
+    model = dist_reconvolution_model(
+        global_popt, tcspc_res, n_bins, irf, 2, 'gaussian',
+        0.0, False, False)
+    decay = np.random.default_rng(13).poisson(model).astype(float)
+
+    maps = fit_per_pixel_dist(
+        decay[None, None, :], tcspc_res, n_bins, irf,
+        global_popt, 2, 'gaussian', fit_bg=False, fit_sigma=False,
+        min_photons=1, use_gpu=False)
+    fitted_popt = np.array([
+        maps['tau_center_1'][0, 0] * 1e-9,
+        maps['tau_center_2'][0, 0] * 1e-9,
+        maps['width_1'][0, 0] * 1e-9,
+        maps['width_2'][0, 0] * 1e-9,
+        maps['alpha_1'][0, 0], maps['alpha_2'][0, 0], 0.0])
+    bg = estimate_bg(decay, int(np.argmax(decay)))
+    fitted_model = dist_reconvolution_model(
+        fitted_popt, tcspc_res, n_bins, irf, 2, 'gaussian',
+        bg, False, False)
+
+    assert maps['calibrated_chi2'][0, 0] == pytest.approx(
+        calibrated_chi2(decay, fitted_model))
+
+
+def test_batch_exports_include_calibrated_map():
+    from flimkit.utils.batch_fit import _STACK_MAPS
+
+    assert 'calibrated_chi2' in _STACK_MAPS
+
+
+def test_stitch_adapter_keeps_calibrated_map():
+    from flimkit.formats.PTU.stitch import _adapt_pixel_maps
+
+    pixel_maps = {
+        'intensity': np.ones((1, 1)),
+        'tau_mean_amp': np.ones((1, 1)),
+        'chi2_r': np.ones((1, 1)),
+        'calibrated_chi2': np.full((1, 1), 1.25),
+    }
+
+    adapted = _adapt_pixel_maps(pixel_maps, 1, np.array([2.0]))
+
+    assert adapted['calibrated_chi2'][0, 0] == pytest.approx(1.25)
+
+
+def test_assembled_canvas_keeps_calibrated_map():
+    from flimkit.FLIM.assemble import assemble_tile_maps
+
+    pixel_maps = {
+        'intensity': np.ones((1, 1)),
+        'tau_mean_amp': np.ones((1, 1)),
+        'calibrated_chi2': np.full((1, 1), 1.25),
+        'tau1': np.full((1, 1), 2.0),
+        'a1': np.ones((1, 1)),
+    }
+    tile_results = [{
+        'pixel_maps': pixel_maps,
+        'pixel_y': 0,
+        'pixel_x': 0,
+        'tile_h': 1,
+        'tile_w': 1,
+    }]
+
+    canvas = assemble_tile_maps(tile_results, 1, 1, 1)
+
+    assert canvas['calibrated_chi2'][0, 0] == pytest.approx(1.25)
+
+
+def test_zstack_display_restores_calibrated_summed_values(tmp_path):
+    import json
+    from flimkit.UI.flim_display import load_zstack_display_slices
+
+    reference = {
+        'taus_ns': [2.0],
+        'nexp': 1,
+        'calibrated_chi2_pearson': 1.1,
+        'calibrated_chi2_tail_pearson': 0.9,
+    }
+    (tmp_path / 'sample_reference_fit.json').write_text(json.dumps(reference))
+    slice_dir = tmp_path / 'z0000'
+    slice_dir.mkdir()
+    np.save(slice_dir / 'intensity.npy', np.ones((1, 1)))
+
+    slices = load_zstack_display_slices(tmp_path)
+    summary = slices[0]['fit_result']['global_summary']
+
+    assert summary['calibrated_chi2_pearson'] == pytest.approx(1.1)
+    assert summary['calibrated_chi2_tail_pearson'] == pytest.approx(0.9)


### PR DESCRIPTION
## Summary

- preserve all existing reduced chi-square fields and calculations unchanged
- add expected-contribution-normalized values for summed full-window and tail-window fits
- add the same diagnostic to per-pixel CPU, Torch, MLX, and distribution-fitting paths
- persist the new per-pixel map and summed reference values through batch and stitching outputs

## Rationale

For fixed Poisson counts with model mean $m_i$, the expected contribution of the existing floored model-weighted residual is:

$$E\left[\frac{(Y_i-m_i)^2}{\max(m_i,1)}\right]=\min(m_i,1).$$

The new diagnostic therefore uses:

$$Q_{\mathrm{cal}}=\frac{\sum_i (Y_i-m_i)^2/\max(m_i,1)}{\sum_i\min(m_i,1)}.$$

This keeps the existing residual numerator while normalizing by its expected fixed-model contribution.

## New outputs

- `calibrated_chi2_pearson`: summed fitting window
- `calibrated_chi2_tail_pearson`: summed tail window
- `calibrated_chi2`: per-pixel map

The shared helper supports scalar and batched reductions. Invalid, negative, non-finite, or all-zero inputs return `NaN` rather than producing an uncontrolled division.

## Interpretation

For a fixed correct Poisson model and fixed bins, the expected value is one. Parameter fitting and data-selected windows can introduce an additional shift, so this is a diagnostic rather than a classical chi-square p-value.

## Tests

- 19 focused calibration tests passed
- 183 focused and related tests passed

Full local non-data suite:

```text
625 passed, 26 skipped, 2 failed
```

The two failures are existing order-dependent CPU/GPU TVB parity failures. They reproduce on unchanged upstream `main` under the same test order and pass when run individually.

Python syntax compilation and `git diff --check` also passed.

## Naming

The helper and per-pixel map are currently named `calibrated_chi2`, with summed fields named `calibrated_chi2_pearson` and `calibrated_chi2_tail_pearson`. Are these names acceptable, or would names that explicitly mention expected-contribution normalization be preferable?

## Scope

- no change to the existing reduced chi-square fields or calculations
- no change to optimizer cost functions or fitting models
- no classical p-value is assigned to the new diagnostic
- documentation placement is intentionally left unchanged pending the discussion in #28

References #27 and #28. Sorry if this is too convoluted, I'm working on the code as well as documentation and tried keep them separated. 
