### PR TITLE
Document fit diagnostics

### DIFF
--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -746,6 +746,26 @@ Pixel values outside the range are clamped to the boundary, not zeroed.
 | `poisson` | Poisson deviance (C-statistic). Recommended |
 | `chi2` | Neyman chi-squared (legacy)  |
 
+### Fit Diagnostics
+
+The cost function above selects the optimizer objective. The fields below are
+post-fit diagnostics and do not change how the model is fitted.
+
+The existing `reduced_chi2_pearson`, `reduced_chi2_tail_pearson`, and per-pixel
+`chi2_r` fields are retained for compatibility with historical Leica LAS X
+comparisons. Their one-count model floor means they are not generally expected
+to equal one for sparse decays.
+
+`calibrated_chi2_pearson`, `calibrated_chi2_tail_pearson`, and the per-pixel
+`calibrated_chi2_r` map divide the same residual sum by its expected
+contribution under a fixed Poisson model:
+
+$$Q_{\mathrm{cal}} = \frac{\sum_i (Y_i-m_i)^2/\max(m_i,1)}{\sum_i \min(m_i,1)}.$$
+
+The fixed-model expectation is one. Parameter fitting and data-selected windows
+can introduce a smaller additional shift, so this diagnostic is not a classical
+chi-square p-value.
+
 ---
 
 ## Module Reference


### PR DESCRIPTION
## Summary

- explain the difference between optimizer cost functions and post-fit diagnostics
- document the legacy reduced chi-square fields and their sparse-count limitation
- document the expected-contribution-normalized summed fields and per-pixel map
- state the fixed-model expectation and interpretation limit

## Verification

- built the generated wiki preview successfully: 15 pages, `Home.md`, and `_Sidebar.md`
- confirmed the change appears under Configuration Reference next to Cost Functions
- `git diff --check` passed

This PR changes only `Docs/documentation.md`.

References #28 and #29.
