### PR TITLE
Prevent TF32 drift in TVB CUDA grid scans

### DIFF
--- a/flimkit/GPU/torch_backend.py
+++ b/flimkit/GPU/torch_backend.py
@@ -1,6 +1,10 @@
+import threading
+
 import numpy as np
 from flimkit.GPU._base import _BackendMixin
 from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
+
+_MATMUL_PRECISION_LOCK = threading.Lock()
 
 class TorchBackend(_BackendMixin):
 
@@ -8,6 +12,17 @@ class TorchBackend(_BackendMixin):
         import torch
         self._torch = torch
         self.device = torch.device(device)
+
+    def _matmul_full_precision(self, left, right):
+        if self.device.type != 'cuda':
+            return left @ right
+        with _MATMUL_PRECISION_LOCK:
+            previous = self._torch.get_float32_matmul_precision()
+            self._torch.set_float32_matmul_precision('highest')
+            try:
+                return left @ right
+            finally:
+                self._torch.set_float32_matmul_precision(previous)
 
     def __repr__(self):
         return f"TorchBackend(device='{self.device}')"
@@ -120,7 +135,7 @@ class TorchBackend(_BackendMixin):
             basis_t = torch.as_tensor(basis_perp, dtype=torch.float32, device=self.device)
             bbp_t = torch.as_tensor(bb_perp, dtype=torch.float32, device=self.device)
             dperp_t = torch.as_tensor(d_perp, dtype=torch.float32, device=self.device)
-            bd = dperp_t @ basis_t.T
+            bd = self._matmul_full_precision(dperp_t, basis_t.T)
             dsq = (dperp_t ** 2).sum(dim=1)
             costs = dsq[:, None] - torch.clamp(bd, min=0.0) ** 2 / bbp_t[None, :]
             best_g = costs.argmin(dim=1).cpu().numpy()
@@ -276,7 +291,7 @@ class TorchBackend(_BackendMixin):
             basis_pt = torch.as_tensor(basis_perp, dtype=torch.float32, device=self.device)
             bbp_t = torch.as_tensor(bb_perp, dtype=torch.float32, device=self.device)
             dperp_t = torch.as_tensor(d_perp, dtype=torch.float32, device=self.device)
-            bd_t = dperp_t @ basis_pt.T
+            bd_t = self._matmul_full_precision(dperp_t, basis_pt.T)
             dsq_t = (dperp_t ** 2).sum(dim=1)
             costs_t = dsq_t[:, None] - torch.clamp(bd_t, min=0.0) ** 2 / bbp_t[None, :]
             best_g = costs_t.argmin(dim=1).cpu().numpy()

--- a/flimkit_tests/tests/test_gpu_backends.py
+++ b/flimkit_tests/tests/test_gpu_backends.py
@@ -106,7 +106,97 @@ class TestBackendDetection:
             result = gpu_mod.get_backend(prefer="mps")
         assert result is mps_sentinel
 
-# 2.  TestApproxNNLSVsTrueNNLS
+# 2.  TestTorchPrecision
+class TestTorchPrecision:
+    def test_cuda_matmul_uses_highest_precision_and_restores_setting(self):
+        torch = pytest.importorskip('torch')
+        from flimkit.GPU.torch_backend import TorchBackend
+
+        observed = []
+
+        class Probe:
+            def __matmul__(self, other):
+                observed.append(torch.get_float32_matmul_precision())
+                return 'result'
+
+        previous = torch.get_float32_matmul_precision()
+        try:
+            torch.set_float32_matmul_precision('high')
+            backend = TorchBackend(device='cuda')
+            result = backend._matmul_full_precision(Probe(), object())
+            assert result == 'result'
+            assert observed == ['highest']
+            assert torch.get_float32_matmul_precision() == 'high'
+        finally:
+            torch.set_float32_matmul_precision(previous)
+
+    def test_cuda_matmul_restores_precision_after_exception(self):
+        torch = pytest.importorskip('torch')
+        from flimkit.GPU.torch_backend import TorchBackend
+
+        class FailingProbe:
+            def __matmul__(self, other):
+                raise RuntimeError('matmul failed')
+
+        previous = torch.get_float32_matmul_precision()
+        try:
+            torch.set_float32_matmul_precision('high')
+            backend = TorchBackend(device='cuda')
+            with pytest.raises(RuntimeError, match='matmul failed'):
+                backend._matmul_full_precision(FailingProbe(), object())
+            assert torch.get_float32_matmul_precision() == 'high'
+        finally:
+            torch.set_float32_matmul_precision(previous)
+
+    def test_concurrent_cuda_matmuls_restore_original_precision(self):
+        import threading
+
+        torch = pytest.importorskip('torch')
+        from flimkit.GPU.torch_backend import TorchBackend
+
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        first_finished = threading.Event()
+
+        class FirstProbe:
+            def __matmul__(self, other):
+                first_entered.set()
+                second_entered.wait(timeout=0.2)
+                return 'first'
+
+        class SecondProbe:
+            def __matmul__(self, other):
+                second_entered.set()
+                first_finished.wait(timeout=0.2)
+                return 'second'
+
+        backend = TorchBackend(device='cuda')
+        previous = torch.get_float32_matmul_precision()
+        try:
+            torch.set_float32_matmul_precision('high')
+
+            def run_first():
+                backend._matmul_full_precision(FirstProbe(), object())
+                first_finished.set()
+
+            first = threading.Thread(target=run_first)
+            second = threading.Thread(
+                target=backend._matmul_full_precision,
+                args=(SecondProbe(), object()),
+            )
+            first.start()
+            assert first_entered.wait(timeout=1.0)
+            second.start()
+            first.join(timeout=1.0)
+            second.join(timeout=1.0)
+            assert not first.is_alive()
+            assert not second.is_alive()
+            assert torch.get_float32_matmul_precision() == 'high'
+        finally:
+            torch.set_float32_matmul_precision(previous)
+
+
+# 3.  TestApproxNNLSVsTrueNNLS
 class TestApproxNNLSVsTrueNNLS:
     """
     Validates that clamp(pinv(A) @ d, 0) ≈ scipy.nnls(A, d) for
@@ -147,7 +237,7 @@ class TestApproxNNLSVsTrueNNLS:
             amps = np.maximum(A_pinv @ d, 0.0)
             assert np.all(amps >= 0.0)
 
-# 3.  TestBatchFixedTauCPUParity
+# 4.  TestBatchFixedTauCPUParity
 class TestBatchFixedTauCPUParity:
     """
     Compare GPU batch_fixed_tau output to the CPU pixel loop for a small
@@ -227,7 +317,7 @@ class TestBatchFixedTauCPUParity:
         )
 
 
-# 4.  TestBatchGrid1ExpCPUParity
+# 5.  TestBatchGrid1ExpCPUParity
 class TestBatchGrid1ExpCPUParity:
     """Compare GPU batch_grid_scan_1exp to the vectorised CPU row loop."""
 
@@ -287,7 +377,7 @@ class TestBatchGrid1ExpCPUParity:
             progress_callback=None)
         np.testing.assert_array_equal(maps["intensity"], stack.sum(axis=2))
 
-# 5.  TestGPUFitPerPixelIntegration
+# 6.  TestGPUFitPerPixelIntegration
 class TestGPUFitPerPixelIntegration:
     """
     Smoke-test the use_gpu=True path inside fit_per_pixel().


### PR DESCRIPTION
Closes #30.

## Problem

Importing Cellpose changes PyTorch's process-wide float32 matrix-multiplication precision from `highest` to `high`, which enables TF32 on CUDA. The TVB grid scans compare very close projected costs. TF32 rounding can therefore move the selected lifetime by one or more grid bins.

This explains the order-dependent behavior:

- the two TVB CPU/CUDA parity tests passed by themselves
- they failed after the complete stitching workflow imported Cellpose
- the CPU results did not change
- the CUDA results changed by 0.062 ns and 0.131 ns

## Fix

- run the two affected TVB projection matrix multiplications at `highest` float32 precision
- restore the process-wide PyTorch precision setting immediately after each operation
- serialize these temporary setting changes across FLIMKit Torch backends
- add regression tests for normal completion, exceptions, and concurrent calls

This affects only the Torch CUDA and ROCm TVB grid-scan projections. CPU, MLX, MPS, and non-TVB Torch behavior are unchanged. Other libraries keep their chosen PyTorch precision setting outside these two short operations.

## Verification

- focused Torch backend, TVB, and triggering workflow tests: 47 passed
- full non-data suite: 630 passed, 26 skipped
- `py_compile`: passed
- `git diff --check`: passed
