### PR TITLE
chore: point the docs at the new repository home

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions and discussion
-    url: https://github.com/alex1075/FLIMKit/discussions
+    url: https://github.com/flimkit/FLIMKit/discussions
     about: For usage questions and open-ended ideas, start a discussion instead of an issue.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,7 @@ authors:
 type: software
 license: MIT
 version: 0.9.19
-repository-code: "https://github.com/alex1075/FLIMKit"
+repository-code: "https://github.com/flimkit/FLIMKit"
 keywords:
   - FLIM
   - TCSPC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@ By taking part in this project you agree to abide by the [Code of Conduct](CODE_
 
 ## Getting support
 
-- **Questions about using FLIMKit:** open an [issue](https://github.com/alex1075/FLIMKit/issues) and label it `question`.
-- **Documentation:** the [wiki](https://github.com/alex1075/FLIMKit/wiki) covers installation, workflows, the module reference, and troubleshooting.
+- **Questions about using FLIMKit:** open an [issue](https://github.com/flimkit/FLIMKit/issues) and label it `question`.
+- **Documentation:** the [wiki](https://github.com/flimkit/FLIMKit/wiki) covers installation, workflows, the module reference, and troubleshooting.
 - **Email:** Alex Hunt, alexander.hunt@ed.ac.uk. Please prefer issues where possible so answers are searchable by other users.
 
 ## Reporting bugs
 
-Open an issue at https://github.com/alex1075/FLIMKit/issues and include:
+Open an issue at https://github.com/flimkit/FLIMKit/issues and include:
 
 - What you ran (the CLI command, GUI action, or a minimal Python snippet).
 - The full traceback, not just the last line.
@@ -27,14 +27,14 @@ FLIM files are often large and sometimes unpublished, so do not attach data you 
 
 ## Sharing sample files
 
-Sample files are the single most useful contribution to a format reader. Several FLIMKit readers were written from vendor specifications and have never been run against a real acquisition, which is the main source of uncertainty in the project. See the [supported formats table](https://github.com/alex1075/FLIMKit/wiki/Supported-Input-Formats) for which readers are validated and which are not.
+Sample files are the single most useful contribution to a format reader. Several FLIMKit readers were written from vendor specifications and have never been run against a real acquisition, which is the main source of uncertainty in the project. See the [supported formats table](https://github.com/flimkit/FLIMKit/wiki/Supported-Input-Formats) for which readers are validated and which are not.
 
 If you can share a file, a calibration sample with a documented lifetime (a dye with a known tau) is ideal. Best of all is a matched pair: the same sample recorded on two instruments, which allows a bin-for-bin cross-check. Only share data you have the right to share.
 
 ## Development setup
 
 ```bash
-git clone https://github.com/alex1075/FLIMKit.git
+git clone https://github.com/flimkit/FLIMKit.git
 cd FLIMKit
 python install.py --dev
 ```

--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -119,7 +119,7 @@ Not decoded yet: T2-mode PTUs (`ptufile` reads the records, but FLIMKit does not
 ### Installation
 
 ```bash
-git clone https://github.com/alex1075/FLIMKit.git
+git clone https://github.com/flimkit/FLIMKit.git
 cd FLIMKit
 python install.py
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="flimkit/UI/icon.png" alt="" width="32" height="32"> FLIMKit
 
-[![tests](https://github.com/alex1075/FLIMKit/actions/workflows/test.yml/badge.svg)](https://github.com/alex1075/FLIMKit/actions/workflows/test.yml)
-[![Python versions](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://github.com/alex1075/FLIMKit#installation)
+[![tests](https://github.com/flimkit/FLIMKit/actions/workflows/test.yml/badge.svg)](https://github.com/flimkit/FLIMKit/actions/workflows/test.yml)
+[![Python versions](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://github.com/flimkit/FLIMKit#installation)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
 
 > **Warning:** Active development. Cross-validate results with other software before drawing conclusions. API and file formats may change without deprecation.
@@ -14,7 +14,7 @@ FLIMKit is a Python toolkit for FLIM data from FLIM microscope systems and commo
 
 Four entry points: desktop GUI, guided terminal UI, CLI scripts, Python API.
 
-[Examples repo](https://github.com/alex1075/FLIMKit-Examples.git) | [Full documentation](https://github.com/alex1075/FLIMKit/wiki)
+[Examples repo](https://github.com/flimkit/FLIMKit-Examples.git) | [Full documentation](https://github.com/flimkit/FLIMKit/wiki)
 
 ## GUI
 
@@ -27,7 +27,7 @@ Desktop GUI showing reconvolution fitting with per-pixel lifetime maps, summed d
 Python ≥ 3.12 required (3.14 recommended, official builds use 3.14).
 
 ```bash
-git clone https://github.com/alex1075/FLIMKit.git
+git clone https://github.com/flimkit/FLIMKit.git
 cd FLIMKit
 python install.py             # auto-detects GPU and installs the right backend
 python validate_installation.py   # 10 checks - all should pass

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ If you hit a problem on an older version, please confirm it still happens on the
 
 Use one of these instead:
 
-1. GitHub's private vulnerability reporting: go to the [Security tab](https://github.com/alex1075/FLIMKit/security/advisories/new) and open a draft advisory. This is preferred, because it keeps the report, the fix, and the disclosure in one place.
+1. GitHub's private vulnerability reporting: go to the [Security tab](https://github.com/flimkit/FLIMKit/security/advisories/new) and open a draft advisory. This is preferred, because it keeps the report, the fix, and the disclosure in one place.
 2. Email alexander.hunt@ed.ac.uk with `FLIMKit security` in the subject line.
 
 Please include:
@@ -57,7 +57,7 @@ FLIMKit runs locally on data you point it at. The realistic risk is a hostile or
 
 **Out of scope:**
 
-- Crashes, hangs, or unhandled exceptions on malformed files with no path to code execution or data loss. Those are ordinary bugs: please [open an issue](https://github.com/alex1075/FLIMKit/issues), they are still worth fixing.
+- Crashes, hangs, or unhandled exceptions on malformed files with no path to code execution or data loss. Those are ordinary bugs: please [open an issue](https://github.com/flimkit/FLIMKit/issues), they are still worth fixing.
 - Running out of memory on a large file or a large fit. See the documented hardware limits.
 - The Panel interface being reachable by other users when you deliberately bind it to a public interface. It is intended for `localhost` and has no authentication layer.
 - Vulnerabilities in a dependency that FLIMKit does not call into. Report those upstream.


### PR DESCRIPTION
FLIMKit now lives at github.com/FLIMKit/FLIMKit. GitHub redirects the old
URLs, so nothing was broken, but the badges, clone lines, wiki links and the
citation metadata should name the real one.

16 references across the README, CONTRIBUTING, SECURITY, the documentation,
the issue template config and CITATION.cff.

update_check.py needs no change: it parses the slug out of the git remote, so
it follows the move on its own. CITATION.cff still points photonsfile at
alex1075/photonsfile, which has not moved.