### PR TITLE
feat: honour the fit window on the GPU per-pixel path

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- The GPU per-pixel path honours a fit window. Fixed-tau and the one-exponential grid scan now take the window and exclusion bands, so dropping a reflection peak out of the fit no longer forces the CPU path, which is the case where the GPU was wanted most. `intensity` and the `min_photons` mask are still computed over the whole decay, matching the CPU, and only the projection and chi-squared see the window. CPU/GPU parity is tested with a window active on both paths. Free-tau, one-exponential with a time-varying background, and tail fits still fall back and say which one applies.
 - In-app explanations of the fit settings. An information icon on the Fitting Parameters, IRF and Masking section headers, and next to the optimizer choice in Expert Fit Settings, opens a single window covering six topics: fit model, component count, fitting mode, optimizer, IRF source and masking. Every option in those sections gets a paragraph on what it does and when to pick it, along with the caveats that are easy to miss: that a lower chi-squared alone does not justify an extra component, that a tau near the IRF width is unresolved rather than measured, and that the Coates correction leaves the decay non-Poisson while the default cost function still assumes it is. The text lives in `flimkit/UI/fit_help.py` and the icons sit inside label rows that already existed, so no panel grew.
 
 ## [0.10.0] - 2026-08-11

--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -21,7 +21,9 @@ Let users define their own decay models and cost functions, and let analysis too
 Models and cost functions are the goal, and they are one job rather than two. The differential evolution costs are twelve hand-written classes covering model against cost function against reparameterisation, so both hooks need the same groundwork first: a parameter-layout object, and one generic cost class in place of the twelve. Tracked in issue #3. Tools, formats and filters come first, since they are close to free by comparison and they prove the registry.
 
 ### 5. GPU per-pixel fitting with a fit window
-The per-pixel fit falls back to CPU whenever a fit window or an exclusion band is set, and says so (`fitters.py`, `[per-pixel] fit window/exclusions active ... GPU backends have no window support yet`). Anyone dropping a reflection peak out of the fit therefore loses the GPU path, which is the case where the speed is wanted most. The projection and the grid scan both need to run over a bin subset rather than the whole histogram, on CUDA, MPS and MLX. Tail fits fall back for the same reason and would be fixed by the same change, since a tail fit is a window starting at t0.
+Fixed-tau and the one-exponential grid scan now honour a fit window and exclusion bands on the GPU, so dropping a reflection peak out of the fit no longer costs the GPU path. `intensity` and the `min_photons` mask stay computed over the whole decay, as on the CPU, and CPU/GPU parity is tested with a window active.
+
+Three cases still fall back, each saying so: free-tau, one-exponential with a time-varying background, and tail fits. The first two are the same shape of change as the ones already done. The tail fit is different, since its window starts at the fitted `t0` rather than at a bin the user chose.
 
 ## Medium Priority - To Do
 

--- a/flimkit/FLIM/fitters.py
+++ b/flimkit/FLIM/fitters.py
@@ -634,13 +634,17 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                              irf_fft=irf_fft, t0=t0_px)
     A = conv_basis.T
     A_fit = A[fit_idx]
-    if _windowed and use_gpu is not False and not _tail:
-        print(f'  [per-pixel] fit window/exclusions active ({len(fit_idx)}/{n_bins} bins); '
-              f'using CPU path (GPU backends have no window support yet)')
     if _tail and use_gpu is not False:
         print(f'  [per-pixel] tail fit uses the CPU path; the projection has to be '
               f'restricted to bins past t0')
-    if use_gpu is not False and not _windowed and not _tail:
+    if _windowed and use_gpu is not False and not _tail and free_tau:
+        print(f'  [per-pixel] fit window/exclusions active ({len(fit_idx)}/{n_bins} bins); '
+              f'free-tau has no window support on the GPU yet, using the CPU path')
+    _gpu_windowed_ok = not (_windowed and (free_tau or (n_exp == 1 and tvb_on)))
+    if _windowed and use_gpu is not False and not _tail and n_exp == 1 and tvb_on:
+        print(f'  [per-pixel] fit window with a time-varying background is not supported '
+              f'on the GPU for one-exponential fits, using the CPU path')
+    if use_gpu is not False and not _tail and _gpu_windowed_ok:
         _backend = gpu_backend if gpu_backend is not None else (
             None if _gpu_backend_cache is _GPU_BACKEND_UNSET else _gpu_backend_cache
         )
@@ -665,6 +669,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                         progress_callback,
                         tvb_profile=tvb_profile if tvb_on else None,
                         fit_tvb=tvb_on,
+                        fit_idx=fit_idx if _windowed else None,
                     )
                 else:
                     return _backend.batch_fixed_tau(
@@ -673,6 +678,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
                         progress_callback,
                         tvb_profile=tvb_profile if tvb_on else None,
                         fit_tvb=tvb_on,
+                        fit_idx=fit_idx if _windowed else None,
                     )
             else:
                 _tau_min_s = (tau_min_ns if tau_min_ns is not None

--- a/flimkit/GPU/_base.py
+++ b/flimkit/GPU/_base.py
@@ -5,6 +5,15 @@ from scipy.optimize import least_squares
 from ..FLIM.fit_tools import calibrated_chi2
 from ..FLIM.models import reconvolution_model
 
+def fit_window(fit_idx, n_bins):
+    if fit_idx is None:
+        return None
+    idx = np.asarray(fit_idx, dtype=int)
+    if idx.size == n_bins:
+        return None
+    return idx
+
+
 class GPUBackend:
 
     def batch_fixed_tau(
@@ -16,6 +25,7 @@ class GPUBackend:
         correct_pileup,
         n_sync_px,
         progress_callback,
+        fit_idx=None,
     ):
         raise NotImplementedError
 
@@ -29,6 +39,7 @@ class GPUBackend:
         correct_pileup,
         n_sync_px,
         progress_callback,
+        fit_idx=None,
     ):
         raise NotImplementedError
 

--- a/flimkit/GPU/mlx_backend.py
+++ b/flimkit/GPU/mlx_backend.py
@@ -1,5 +1,5 @@
 import numpy as np
-from flimkit.GPU._base import _BackendMixin
+from flimkit.GPU._base import _BackendMixin, fit_window
 from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
 
 class MLXBackend(_BackendMixin):
@@ -23,12 +23,15 @@ class MLXBackend(_BackendMixin):
         progress_callback=None,
         tvb_profile=None,
         fit_tvb=False,
+        fit_idx=None,
     ):
         mx = self._mx
         ny, nx, n_bins = stack.shape
         n_exp = A.shape[1]
         taus_ns = taus_fixed * 1e9
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
+        win = fit_window(fit_idx, n_bins)
+        A = A if win is None else A[win]
         intensity_flat = flat.sum(axis=1)
         valid_mask = intensity_flat >= min_photons
         valid_idx = np.where(valid_mask)[0]
@@ -43,8 +46,10 @@ class MLXBackend(_BackendMixin):
         tvb_np = None
         if fit_tvb and tvb_profile is not None:
             B_col = np.asarray(tvb_profile, dtype=np.float32)
-            A_aug = np.column_stack([A, B_col, np.ones(n_bins, dtype=np.float32)]).astype(np.float32)
-            data_in = flat.copy()
+            B_col = B_col if win is None else B_col[win]
+            A_aug = np.column_stack(
+                [A, B_col, np.ones(A.shape[0], dtype=np.float32)]).astype(np.float32)
+            data_in = flat.copy() if win is None else flat[:, win].copy()
             if correct_pileup and n_sync_px > 0:
                 for idx in valid_idx:
                     data_in[idx] = coates_pileup_correction(data_in[idx], n_sync_px)
@@ -58,6 +63,7 @@ class MLXBackend(_BackendMixin):
         else:
             bg_flat = self._estimate_bg_batch(flat, valid_mask)
             dc_flat = np.maximum(flat - bg_flat[:, None], 0.0)
+            dc_flat = dc_flat if win is None else dc_flat[:, win]
             if correct_pileup and n_sync_px > 0:
                 for idx in valid_idx:
                     dc_flat[idx] = coates_pileup_correction(dc_flat[idx], n_sync_px)
@@ -73,13 +79,12 @@ class MLXBackend(_BackendMixin):
             valid_idx = valid_idx,
             amps = amps_np[valid_idx],
             bg = bg_np[valid_idx],
-            decay_valid= flat[valid_idx],
+            decay_valid= flat[valid_idx] if win is None else flat[valid_idx][:, win],
             A = A,
             taus_ns = taus_ns,
             ny=ny, nx=nx,
             tvb = tvb_np[valid_idx] if tvb_np is not None else None,
-            tvb_profile = np.asarray(tvb_profile, dtype=np.float32)
-                         if (fit_tvb and tvb_profile is not None) else None,
+            tvb_profile = (B_col if (fit_tvb and tvb_profile is not None) else None),
         )
         return maps
 
@@ -95,11 +100,22 @@ class MLXBackend(_BackendMixin):
         progress_callback=None,
         tvb_profile=None,
         fit_tvb=False,
+        fit_idx=None,
     ):
         mx = self._mx
         ny, nx, n_bins = stack.shape
         N_GRID = len(tau_grid)
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
+        win = fit_window(fit_idx, n_bins)
+        if win is not None:
+            if fit_tvb and tvb_profile is not None:
+                raise ValueError('a fit window with time-varying background is not '
+                                 'supported on the GPU for one-exponential fits')
+            basis_grid = basis_grid[:, win]
+            bb_grid = np.maximum((basis_grid ** 2).sum(axis=1), 1e-20)
+            n_fit = len(win)
+        else:
+            n_fit = n_bins
         intensity_flat = flat.sum(axis=1)
         valid_mask = intensity_flat >= min_photons
         valid_idx = np.where(valid_mask)[0]
@@ -147,7 +163,7 @@ class MLXBackend(_BackendMixin):
         if correct_pileup and n_sync_px > 0:
             for idx in valid_idx:
                 dc_flat[idx] = coates_pileup_correction(dc_flat[idx], n_sync_px)
-        dc_valid = dc_flat[valid_idx]
+        dc_valid = dc_flat[valid_idx] if win is None else dc_flat[valid_idx][:, win]
         basis_mx = mx.array(basis_grid.astype(np.float32))
         bb_mx = mx.array(bb_grid.astype(np.float32))
         dc_mx = mx.array(dc_valid)
@@ -168,10 +184,10 @@ class MLXBackend(_BackendMixin):
             tau_v = tau_v,
             amp_v = amp_v,
             bg_v = bg_flat[valid_idx],
-            decay_valid = flat[valid_idx],
+            decay_valid = flat[valid_idx] if win is None else flat[valid_idx][:, win],
             basis_best = basis_best,
             ny=ny, nx=nx,
-            n_bins=n_bins,
+            n_bins=n_fit,
         )
         return maps
 

--- a/flimkit/GPU/torch_backend.py
+++ b/flimkit/GPU/torch_backend.py
@@ -1,7 +1,7 @@
 import threading
 
 import numpy as np
-from flimkit.GPU._base import _BackendMixin
+from flimkit.GPU._base import _BackendMixin, fit_window
 from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
 
 _MATMUL_PRECISION_LOCK = threading.Lock()
@@ -38,21 +38,26 @@ class TorchBackend(_BackendMixin):
         progress_callback=None,
         tvb_profile=None,
         fit_tvb=False,
+        fit_idx=None,
     ):
         torch = self._torch
         ny, nx, n_bins = stack.shape
         n_exp = A.shape[1]
         taus_ns = taus_fixed * 1e9
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
+        win = fit_window(fit_idx, n_bins)
+        A = A if win is None else A[win]
         intensity_flat = flat.sum(axis=1)
         valid_mask = intensity_flat >= min_photons
         # Compute pinv on CPU - linalg_svd (used internally by pinv) is not supported on MPS and would silently fall back, triggering a UserWarning. :(
         tvb_np = None
         if fit_tvb and tvb_profile is not None:
             B_col = np.asarray(tvb_profile, dtype=np.float32)
-            A_aug = np.column_stack([A, B_col, np.ones(n_bins, dtype=np.float32)]).astype(np.float32)
+            B_col = B_col if win is None else B_col[win]
+            A_aug = np.column_stack(
+                [A, B_col, np.ones(A.shape[0], dtype=np.float32)]).astype(np.float32)
             A_pinv = torch.linalg.pinv(torch.as_tensor(A_aug, device='cpu')).to(self.device)
-            data_in = flat.copy()
+            data_in = flat.copy() if win is None else flat[:, win].copy()
             if correct_pileup and n_sync_px > 0:
                 for idx in np.where(valid_mask)[0]:
                     data_in[idx] = coates_pileup_correction(data_in[idx], n_sync_px)
@@ -66,6 +71,7 @@ class TorchBackend(_BackendMixin):
             A_pinv = torch.linalg.pinv(A_cpu).to(self.device)
             bg_flat = self._estimate_bg_batch(flat, valid_mask)
             data_corr = np.maximum(flat - bg_flat[:, None], 0.0)
+            data_corr = data_corr if win is None else data_corr[:, win]
             if correct_pileup and n_sync_px > 0:
                 for idx in np.where(valid_mask)[0]:
                     data_corr[idx] = coates_pileup_correction(data_corr[idx], n_sync_px)
@@ -86,13 +92,12 @@ class TorchBackend(_BackendMixin):
             valid_idx = valid_idx,
             amps = amps_np[valid_idx],
             bg = bg_np[valid_idx],
-            decay_valid = flat[valid_idx],
+            decay_valid = flat[valid_idx] if win is None else flat[valid_idx][:, win],
             A = A,
             taus_ns = taus_ns,
             ny = ny, nx = nx,
             tvb = tvb_np[valid_idx] if tvb_np is not None else None,
-            tvb_profile= np.asarray(tvb_profile, dtype=np.float32)
-                         if (fit_tvb and tvb_profile is not None) else None,
+            tvb_profile= (B_col if (fit_tvb and tvb_profile is not None) else None),
         )
         return maps
 
@@ -108,11 +113,22 @@ class TorchBackend(_BackendMixin):
         progress_callback=None,
         tvb_profile=None,
         fit_tvb=False,
+        fit_idx=None,
     ):
         torch = self._torch
         ny, nx, n_bins = stack.shape
         N_GRID = len(tau_grid)
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
+        win = fit_window(fit_idx, n_bins)
+        if win is not None:
+            if fit_tvb and tvb_profile is not None:
+                raise ValueError('a fit window with time-varying background is not '
+                                 'supported on the GPU for one-exponential fits')
+            basis_grid = basis_grid[:, win]
+            bb_grid = np.maximum((basis_grid ** 2).sum(axis=1), 1e-20)
+            n_fit = len(win)
+        else:
+            n_fit = n_bins
         intensity_flat = flat.sum(axis=1)
         valid_mask = intensity_flat >= min_photons
         valid_idx = np.where(valid_mask)[0]
@@ -158,7 +174,7 @@ class TorchBackend(_BackendMixin):
         if correct_pileup and n_sync_px > 0:
             for idx in valid_idx:
                 dc_flat[idx] = coates_pileup_correction(dc_flat[idx], n_sync_px)
-        dc_valid = dc_flat[valid_idx]
+        dc_valid = dc_flat[valid_idx] if win is None else dc_flat[valid_idx][:, win]
         bg_t = torch.as_tensor(bb_grid, dtype=torch.float32, device=self.device)
         basis_t = torch.as_tensor(basis_grid, dtype=torch.float32, device=self.device)
         dc_t = torch.as_tensor(dc_valid, dtype=torch.float32, device=self.device)
@@ -179,10 +195,10 @@ class TorchBackend(_BackendMixin):
             tau_v = tau_v,
             amp_v = amp_v,
             bg_v = bg_flat[valid_idx],
-            decay_valid = flat[valid_idx],
+            decay_valid = flat[valid_idx] if win is None else flat[valid_idx][:, win],
             basis_best = basis_best,
             ny = ny, nx = nx,
-            n_bins = n_bins,
+            n_bins = n_fit,
         )
         return maps
 

--- a/flimkit_tests/tests/test_cpu_gpu_parity.py
+++ b/flimkit_tests/tests/test_cpu_gpu_parity.py
@@ -500,3 +500,83 @@ class TestCPUGPUParityFreeTau:
         for label, maps in [("CPU", cpu), ("GPU", gpu)]:
             missing = required - maps.keys()
             assert not missing, f"free-tau 3-exp {label} missing keys: {missing}"
+
+
+FIT_START = 8
+FIT_END = 112
+
+
+def _windowed_idx(n_bins=N_BINS):
+    idx = np.arange(FIT_START, FIT_END)
+    return idx[(idx < 40) | (idx > 52)]
+
+
+def _fit_both_windowed(stack, n_exp, global_popt, gpu_backend, fit_idx):
+    irf_prompt = _make_irf()
+    kwargs = dict(
+        stack       = stack,
+        tcspc_res   = TCSPC_RES,
+        n_bins      = N_BINS,
+        irf_prompt  = irf_prompt,
+        has_tail    = False,
+        fit_bg      = False,
+        fit_sigma   = False,
+        global_popt = global_popt,
+        n_exp       = n_exp,
+        min_photons = MIN_PHOTONS,
+        fit_idx     = fit_idx,
+    )
+    cpu = fit_per_pixel(**kwargs, use_gpu=False)
+    gpu = fit_per_pixel(**kwargs, gpu_backend=gpu_backend)
+    return cpu, gpu
+
+
+class TestCPUGPUParityWindowed1Exp:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, gpu_backend):
+        self.fit_idx = _windowed_idx()
+        stack = _synthetic_stack_1exp(ny=6, nx=8, tau_ns=2.0)
+        self.cpu, self.gpu = _fit_both_windowed(
+            stack, 1, _global_popt_1exp(tau_ns=2.0), gpu_backend, self.fit_idx)
+
+    def test_the_window_is_actually_narrower(self):
+        assert len(self.fit_idx) < N_BINS
+
+    def test_intensity_is_the_full_decay_not_the_window(self):
+        np.testing.assert_array_equal(self.cpu['intensity'], self.gpu['intensity'])
+
+    def test_tau_agrees(self):
+        assert _rel_err(self.cpu['tau_mean_amp'], self.gpu['tau_mean_amp']) < TAU_TOL
+
+    def test_gpu_window_changes_the_answer(self):
+        stack = _synthetic_stack_1exp(ny=6, nx=8, tau_ns=2.0)
+        full = fit_per_pixel(
+            stack=stack, tcspc_res=TCSPC_RES, n_bins=N_BINS, irf_prompt=_make_irf(),
+            has_tail=False, fit_bg=False, fit_sigma=False,
+            global_popt=_global_popt_1exp(tau_ns=2.0), n_exp=1,
+            min_photons=MIN_PHOTONS, use_gpu=False)
+        assert not np.allclose(np.nanmedian(full['chi2_r']),
+                               np.nanmedian(self.gpu['chi2_r']))
+
+
+class TestCPUGPUParityWindowed2Exp:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, gpu_backend):
+        self.fit_idx = _windowed_idx()
+        stack = _synthetic_stack_2exp(ny=6, nx=8)
+        self.cpu, self.gpu = _fit_both_windowed(
+            stack, 2, _global_popt_2exp(), gpu_backend, self.fit_idx)
+
+    def test_tau_mean_amp_agrees(self):
+        assert _rel_err(self.cpu['tau_mean_amp'], self.gpu['tau_mean_amp']) < TAU_TOL
+
+    def test_tau_mean_int_agrees(self):
+        assert _rel_err(self.cpu['tau_mean_int'], self.gpu['tau_mean_int']) < TAU_TOL
+
+    def test_amplitudes_agree(self):
+        assert _rel_err(self.cpu['alpha_1'], self.gpu['alpha_1']) < AMP_TOL
+
+    def test_chi2_agrees(self):
+        assert _rel_err(self.cpu['chi2_r'], self.gpu['chi2_r']) < 0.15


### PR DESCRIPTION
ROADMAP high priority item 5. Setting a fit window or an exclusion band sent the whole per-pixel fit to the CPU, printing `GPU backends have no window support yet`. That is the case where the GPU is wanted most: anyone dropping a reflection peak out of the fit lost it.

The maths never needed to change. The projection uses `A[fit_idx]` against the same rows of the data, so the backends now take `fit_idx` and slice the basis and the decays themselves.

Two things that would have been silent wrongness if handled carelessly:

- `intensity` and the `min_photons` mask stay computed over the **whole** decay, matching the CPU path. Only the projection and the chi-squared see the window.
- The grid scan and the distribution scan share an identical line of code. Only the grid scan is windowed. The one unsupported combination, a window with a time-varying background on a one-exponential fit, is refused in the dispatcher rather than passed to a backend that would ignore it.

Covered: `batch_fixed_tau` and `batch_grid_scan_1exp` on both MLX and Torch.

Still on the CPU, each printing which case applies rather than one message for all three: free-tau, one-exponential with a time-varying background, and tail fits. The tail fit is a different problem, since its window starts at the fitted `t0`.

`test_cpu_gpu_parity.py` gains windowed cases for one and two exponentials: that the window is really narrower, that `intensity` is the full decay rather than the window, that the windowed answer differs from the unwindowed one, and that CPU and GPU agree on tau, amplitudes and chi-squared.

Verified the GPU is genuinely taken rather than falling back: the backend receives `fit_idx` of 104 bins out of 128 and windows the basis itself.

757 passing.