### PR TITLE
fix: align one-component free-tau backend fitting

### DIFF
--- a/flimkit/FLIM/fitters.py
+++ b/flimkit/FLIM/fitters.py
@@ -646,7 +646,7 @@ def fit_per_pixel(stack, tcspc_res, n_bins, irf_prompt,
             None if _gpu_backend_cache is _GPU_BACKEND_UNSET else _gpu_backend_cache
         )
         if _backend is not None:
-            if not free_tau:
+            if not free_tau or n_exp == 1:
                 if stack.nbytes > _GPU_MAX_STACK_BYTES:
                     print(f'  [per-pixel] {stack.nbytes/1e9:.1f} GB cube exceeds GPU limit '
                           f'({_GPU_MAX_STACK_BYTES/1e9:.1f} GB); using memory-safe CPU path')

--- a/flimkit_tests/tests/test_cpu_gpu_parity.py
+++ b/flimkit_tests/tests/test_cpu_gpu_parity.py
@@ -362,9 +362,9 @@ class TestCPUGPUParityDivergenceReport:
             + self._report(3, cpu, gpu))
 
 
-# Free-τ GPU parity tests
-# Adam (GPU) vs LM/TRF (CPU): same forward model, different optimiser.
-# We expect agreement within looser tolerances than fixed-tau.
+# Free-τ backend parity tests
+# One-component fits use the same lifetime grid scan on every path.
+# Multi-component fits use the shared SciPy solver.
 FREE_TAU_TOL     = 0.08
 FREE_TAU_CHI2_MULT = 3.0
 
@@ -390,15 +390,18 @@ def _fit_both_free_tau(stack, n_exp, global_popt, gpu_backend):
 
 
 class TestCPUGPUParityFreeTau:
-    """
-    Free-τ per-pixel: GPU Adam vs CPU Levenberg-Marquardt.
-    Different optimisers reaching the same basin - tested with looser
-    tolerances than the fixed-τ NNLS paths.
-    """
+    """Free-tau per-pixel fitting agrees across backend selection."""
 
     @pytest.fixture(autouse=True)
     def setup(self, gpu_backend):
         self.gpu_backend = gpu_backend
+
+    def test_1exp_free_tau_agrees(self):
+        stack = _synthetic_stack_1exp(ny=4, nx=4, tau_ns=2.0)
+        cpu, gpu = _fit_both_free_tau(
+            stack, 1, _global_popt_1exp(), self.gpu_backend)
+        np.testing.assert_allclose(cpu['tau_1'], gpu['tau_1'], rtol=1e-6)
+        np.testing.assert_allclose(cpu['chi2_r'], gpu['chi2_r'], rtol=1e-4)
 
     # 2-exp free-tau
 
@@ -607,9 +610,14 @@ class TestCPUGPUParityWindowedFreeTau:
         self.gpu = fit_per_pixel(**kwargs, gpu_backend=gpu_backend)
 
     def test_tau_agrees(self):
-        assert _rel_err(self.cpu['tau_1'], self.gpu['tau_1']) < TAU1_TOL
+        np.testing.assert_allclose(
+            self.cpu['tau_1'], self.gpu['tau_1'], rtol=1e-6)
 
-    def test_the_window_reaches_the_gpu_free_tau_path(self):
+    def test_chi2_agrees(self):
+        np.testing.assert_allclose(
+            self.cpu['chi2_r'], self.gpu['chi2_r'], rtol=1e-4)
+
+    def test_the_window_changes_the_answer(self):
         full = fit_per_pixel(
             stack=_synthetic_stack_1exp(ny=4, nx=4, tau_ns=2.0),
             tcspc_res=TCSPC_RES, n_bins=N_BINS, irf_prompt=_make_irf(),


### PR DESCRIPTION
## Stack

This draft is based on `feature/gpu-window-stage2` so that it shows only the fix for #43. After #42 merges, the base can be changed to `main`.

## Summary

Route one-component free-tau per-pixel fitting through the existing lifetime
grid scan on both the direct CPU and backend-selected paths.

This makes CPU, Torch and MLX use the same fitting method for this case.
Multi-component free-tau fitting continues to use the existing SciPy
least-squares path.

Closes #43.

## Investigation

The original report showed that the same one-component synthetic data produced
different results:

| Path | Median lifetime | Median reduced chi-square |
| --- | ---: | ---: |
| CPU | 1.9701 ns | 1.2711 |
| Backend-selected | 1.8193 ns | 1.9931 |

I reproduced these values on the head of #42.

The first hypothesis was that the paths used different IRFs. The direct CPU
path refers to `irf_prompt`, while the backend-selected path receives
`irf_fixed`.

I compared the actual arrays used in the reproduction:

```text
Original IRF equals fixed IRF: true
Maximum absolute difference:   0
```

The global IRF shift was zero and broadening was disabled. The IRFs were
therefore identical and could not explain the disagreement in this case.

Tracing the dispatch and fitting code revealed a different cause:

- the direct CPU path uses the existing 200-point lifetime grid scan whenever
  `n_exp == 1`, including when `free_tau=True`;
- the backend-selected path sees `free_tau=True` and instead uses the general
  SciPy least-squares solver.

The two paths were therefore fitting the same data with different algorithms.

To test this explanation, I sent the backend-selected one-component fit through
the existing grid scan. The results then agreed:

```text
CPU median lifetime:       1.9701176 ns
Backend median lifetime:   1.9701176 ns
Lifetime difference:       0
Chi-square relative error: approximately 1.2e-8
```

I also checked the two-component free-tau path. Its CPU and backend results
already agreed:

```text
tau 1 relative difference: approximately 1.7e-8
tau 2 relative difference: approximately 3.5e-8
chi-square difference:     0
```

This narrows the problem to one-component free-tau routing rather than the
general multi-component solver.

## Change

Treat `n_exp == 1` as the existing grid-scan case before dispatching to the
general free-tau solver.

Conceptually, the dispatcher changes from:

```python
if not free_tau:
```

to:

```python
if not free_tau or n_exp == 1:
```

The multi-component free-tau path is unchanged.

## Why use the grid scan?

The direct CPU implementation already defines one-component per-pixel fitting
as a lifetime grid scan. The Torch and MLX backends already implement the same
grid scan and support the fit window added in #41.

Using that existing path:

- restores CPU/backend parity;
- avoids introducing another fitting method for the same option;
- preserves the current CPU behaviour;
- leaves multi-component free-tau fitting unchanged;
- uses the accelerated backend implementation where available.

## Tests

The regression tests now cover both the original unwindowed case from #43 and
the windowed path from #42.

The one-component lifetime comparison is tightened from the previous 12%
tolerance to `rtol=1e-6`. A chi-square parity check is added with
`rtol=1e-4`, which remains far below the original disagreement while allowing
small backend-order floating-point variation.

The existing multi-component free-tau tests remain unchanged.

## Verification

- CPU/backend parity tests: 53 passed
- Full local suite: 719 passed, 42 skipped
- GitHub Actions pending
