### PR TITLE
fix: honour fit windows in per-pixel distribution fitting

### DIFF
--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -25,7 +25,7 @@ Fixed-tau and the one-exponential grid scan now honour a fit window and exclusio
 
 Free-tau honours it too, by slicing the residual: that path is `least_squares` per pixel across a thread pool rather than GPU maths, so there was no kernel to change. Two cases still fall back and say so: one-exponential with a time-varying background, and tail fits. The tail fit is different, since its window starts at the fitted `t0` rather than at a bin the user chose.
 
-The per-pixel distribution fit is a separate gap rather than a GPU one. `fit_summed_dist` takes `fit_start_ns`, `fit_end_ns` and `exclude_ns`, but `fit_per_pixel_dist` has no window parameter at all, so with a Gaussian or Lorentzian model the window applies to the summed fit and is ignored for every per-pixel map.
+Per-pixel Gaussian and Lorentzian distribution fits now receive the same selected bins as the summed fit. The CPU, Torch and MLX paths restrict the distribution projection, iterative residual and fit diagnostics to those bins, while background estimation, `intensity` and the `min_photons` mask continue to use the whole decay.
 
 ## Medium Priority - To Do
 

--- a/flimkit/FLIM/fit_tools.py
+++ b/flimkit/FLIM/fit_tools.py
@@ -3,6 +3,11 @@ from scipy.ndimage import gaussian_filter1d
 from scipy.optimize import curve_fit
 
 
+def distribution_dof(n_fit, n_components=1, fit_tvb=False):
+    n_params = 3 * n_components + 1 + int(fit_tvb)
+    return max(int(n_fit) - n_params, 1)
+
+
 def calibrated_chi2(data, model, axis=None):
     data_arr, model_arr = np.broadcast_arrays(
         np.asarray(data, dtype=float), np.asarray(model, dtype=float))

--- a/flimkit/FLIM/fitters.py
+++ b/flimkit/FLIM/fitters.py
@@ -9,7 +9,7 @@ from ..FLIM.irf_tools import build_full_irf
 from ..FLIM.fit_tools import (estimate_bg, find_fit_start, find_fit_end, _build_bounds,
                               _pack_p0, coates_pileup_correction, bins_from_ns, build_fit_idx,
                               find_tail_fit_start, _build_bounds_tail, _pack_p0_tail,
-                              calibrated_chi2)
+                              calibrated_chi2, distribution_dof)
 from ..FLIM.models import (reconvolution_model, _DECost, _DECostLogTau,
                            _DECostPoisson, _DECostPoissonLogTau,
                            dist_reconvolution_model, build_dist_basis_grid,
@@ -1241,8 +1241,14 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                        progress_callback=None,
                        use_gpu='auto',
                        gpu_backend=None,
-                       tvb_profile=None, fit_tvb=False) -> dict:
+                       tvb_profile=None, fit_tvb=False,
+                       fit_idx=None) -> dict:
+    from ..GPU._base import fit_window
+
     ny, nx, _ = stack.shape
+    window = fit_window(fit_idx, n_bins)
+    fit_idx = np.arange(n_bins) if window is None else window
+    n_fit = len(fit_idx)
     tvb_on = bool(fit_tvb) and tvb_profile is not None
     if tvb_on and n_components != 1:
         print('  Per-pixel distribution TVB only supported for unimodal (1 component); ignoring TVB here.')
@@ -1264,7 +1270,8 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
     print(f"  Building distribution basis grid ({n_tau_grid}×{n_width_grid})...")
     basis, param_pairs = build_dist_basis_grid(
         tcspc_res, n_bins, irf_fixed, tau_grid, width_grid, dist_type)
-    bb_grid = np.maximum((basis.astype(np.float64) ** 2).sum(axis=1), 1e-20).astype(np.float32)
+    basis_fit = basis[:, fit_idx]
+    bb_grid = np.maximum((basis_fit.astype(np.float64) ** 2).sum(axis=1), 1e-20).astype(np.float32)
     maps = dict(
         intensity = stack.sum(axis=2),
         tau_mean_amp = np.full((ny, nx), np.nan),
@@ -1280,44 +1287,47 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
     if tvb_on:
         maps['tvb_scale'] = np.full((ny, nx), np.nan)
     if n_components == 1:
-        backend = gpu_backend if gpu_backend is not None else (
-            None if _gpu_backend_cache is _GPU_BACKEND_UNSET else _gpu_backend_cache
-        )
+        backend = None
+        if use_gpu is not False:
+            backend = gpu_backend if gpu_backend is not None else (
+                None if _gpu_backend_cache is _GPU_BACKEND_UNSET else _gpu_backend_cache
+            )
         if backend is not None and stack.nbytes > _GPU_MAX_STACK_BYTES:
             print(f'  [per-pixel] {stack.nbytes/1e9:.1f} GB cube exceeds GPU limit '
                   f'({_GPU_MAX_STACK_BYTES/1e9:.1f} GB); using memory-safe CPU path')
             backend = None
         if backend is not None:
             return backend.batch_dist_scan_unimodal(
-                stack, basis, bb_grid, param_pairs,
+                stack, basis_fit, bb_grid, param_pairs,
                 irf_fixed, tcspc_res, n_bins, dist_type,
                 min_photons, progress_callback,
                 tvb_profile=tvb_profile if tvb_on else None,
-                fit_tvb=tvb_on)
+                fit_tvb=tvb_on, fit_idx=fit_idx)
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
         ph_counts = flat.sum(axis=1)
         valid_idx = np.where(ph_counts >= min_photons)[0]
         if tvb_on and valid_idx.size > 0:
-            _U = np.column_stack([np.asarray(tvb_profile, dtype=float), np.ones(n_bins)])
+            tvb_fit = np.asarray(tvb_profile, dtype=float)[fit_idx]
+            _U = np.column_stack([tvb_fit, np.ones(n_fit)])
             _Up = np.linalg.pinv(_U)
-            _bp = basis.astype(np.float64) - (basis.astype(np.float64) @ _Up.T) @ _U.T
+            _bp = basis_fit.astype(np.float64) - (basis_fit.astype(np.float64) @ _Up.T) @ _U.T
             _bbp = np.maximum((_bp ** 2).sum(axis=1), 1e-20)
-            d_valid = flat[valid_idx].astype(np.float64)
+            d_valid = flat[valid_idx][:, fit_idx].astype(np.float64)
             d_perp = d_valid - (d_valid @ _Up.T) @ _U.T
             bd = d_perp @ _bp.T
             costs = (d_perp ** 2).sum(axis=1)[:, None] - np.maximum(bd, 0.0) ** 2 / _bbp[None, :]
             best_g = np.argmin(costs, axis=1)
             amp_v = np.maximum(bd[np.arange(len(valid_idx)), best_g] / _bbp[best_g], 0.0)
-            basis_best = basis[best_g].astype(np.float64)
+            basis_best = basis_fit[best_g].astype(np.float64)
             resid_after = d_valid - amp_v[:, None] * basis_best
             vz = resid_after @ _Up.T
             tvb_v = np.maximum(vz[:, 0], 0.0)
             bg_z = vz[:, 1]
-            B_arr = np.asarray(tvb_profile, dtype=np.float64)
             tau_v = param_pairs[best_g, 0]
             w_v = param_pairs[best_g, 1]
-            model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * B_arr[None, :] + bg_z[:, None]
-            chi2_v = ((d_valid - model_v) ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+            model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * tvb_fit[None, :] + bg_z[:, None]
+            chi2_v = ((d_valid - model_v) ** 2 / np.maximum(model_v, 1.0)).sum(axis=1)
+            chi2_v /= distribution_dof(n_fit, 1, True)
             chi2_cal_v = calibrated_chi2(d_valid, model_v, axis=1)
             for k, fi in enumerate(valid_idx):
                 if amp_v[k] <= 0:
@@ -1343,9 +1353,10 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 if ph_counts[flat_idx] < min_photons:
                     continue
                 d = flat[flat_idx].astype(np.float64)
+                d_fit = d[fit_idx]
                 bg = estimate_bg(d, int(np.argmax(d)))
-                dc = np.maximum(d - bg, 0.0)
-                bd = basis.astype(np.float64) @ dc
+                dc = np.maximum(d_fit - bg, 0.0)
+                bd = basis_fit.astype(np.float64) @ dc
                 amps_g = np.maximum(bd / bb_grid.astype(np.float64), 0.0)
                 costs = (dc ** 2).sum() - np.maximum(bd, 0.0) ** 2 / bb_grid.astype(np.float64)
                 best = int(np.argmin(costs))
@@ -1354,8 +1365,8 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 amp_px = float(amps_g[best])
                 tau_amp_ns = tau_c_px * 1e9
                 tau_int_ns = (tau_c_px + (w_px ** 2) / max(tau_c_px, 1e-15)) * 1e9
-                model_px = amp_px * basis[best].astype(np.float64) + bg
-                resid_px = d - model_px
+                model_px = amp_px * basis_fit[best].astype(np.float64) + bg
+                resid_px = d_fit - model_px
                 chi2_px = float(np.sum(resid_px ** 2 / np.maximum(model_px, 1.0)))
                 maps['tau_center_1'][row_i, xi] = tau_c_px * 1e9
                 maps['width_1'][row_i, xi] = w_px * 1e9
@@ -1363,8 +1374,8 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 maps['frac_1'][row_i, xi] = 1.0
                 maps['tau_mean_amp'][row_i, xi] = tau_amp_ns
                 maps['tau_mean_int'][row_i, xi] = tau_int_ns
-                maps['chi2_r'][row_i, xi] = chi2_px / max(n_bins - 3, 1)
-                maps['calibrated_chi2_r'][row_i, xi] = calibrated_chi2(d, model_px)
+                maps['chi2_r'][row_i, xi] = chi2_px / distribution_dof(n_fit, 1, False)
+                maps['calibrated_chi2_r'][row_i, xi] = calibrated_chi2(d_fit, model_px)
     else:
         from ..FLIM.fit_tools import estimate_bg as _ebg
         from concurrent.futures import ThreadPoolExecutor
@@ -1375,16 +1386,17 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
         tau_hi_s = tau_centers_g.max() * 5.0
         w_lo_s = widths_g.min() / 5.0
         w_hi_s = widths_g.max() * 5.0
-        amp_hi = float(stack.max()) * 10.0
+        fit_stack_max = float(stack[..., fit_idx].max())
+        amp_hi = fit_stack_max * 10.0
         lo_px = np.array([tau_lo_s] * n_components + [w_lo_s] * n_components + [0.0] * n_components)
         hi_px = np.array([tau_hi_s] * n_components + [w_hi_s] * n_components + [amp_hi] * n_components)
         p0_px = np.concatenate([tau_centers_g, widths_g,
-                                 np.full(n_components, float(stack.max()) / n_components)])
+                                np.full(n_components, fit_stack_max / n_components)])
         def _fit_pixel_dist(flat_idx):
             d = flat[flat_idx].astype(np.float64)
+            d_fit = d[fit_idx]
             bg = _ebg(d, int(np.argmax(d)))
-            dc = np.maximum(d - bg, 0.0)
-            wt = np.sqrt(np.maximum(d, 1.0))
+            wt_fit = np.sqrt(np.maximum(d_fit, 1.0))
             def _resid(p):
                 full_p = np.concatenate([p, [shift]])
                 if fit_sigma:
@@ -1394,7 +1406,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
                 m = dist_reconvolution_model(
                     full_p, tcspc_res, n_bins, irf_prompt,
                     n_components, dist_type, bg, False, False)
-                return (m - d) / wt
+                return (m[fit_idx] - d_fit) / wt_fit
             try:
                 res = least_squares(_resid, p0_px, bounds=(lo_px, hi_px),
                                     method='trf', max_nfev=500,
@@ -1427,6 +1439,7 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
             maps['tau_mean_amp'][yi, xi] = tau_amp_ns
             maps['tau_mean_int'][yi, xi] = tau_int_ns
             d = flat[flat_idx].astype(np.float64)
+            d_fit = d[fit_idx]
             bg = _ebg(d, int(np.argmax(d)))
             full_p = np.concatenate([sol, [shift]])
             if fit_sigma:
@@ -1436,7 +1449,13 @@ def fit_per_pixel_dist(stack, tcspc_res, n_bins, irf_prompt,
             model_px = dist_reconvolution_model(
                 full_p, tcspc_res, n_bins, irf_prompt,
                 n_components, dist_type, bg, False, False)
-            maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(d, model_px)
+            model_fit = model_px[fit_idx]
+            resid_fit = d_fit - model_fit
+            chi2_px = float(np.sum(resid_fit ** 2 / np.maximum(model_fit, 1.0)))
+            maps['chi2_r'][yi, xi] = chi2_px / distribution_dof(
+                n_fit, n_components, False)
+            maps['calibrated_chi2_r'][yi, xi] = calibrated_chi2(
+                d_fit, model_fit)
             for i in range(n_components):
                 maps[f"tau_center_{i+1}"][yi, xi] = tau_cs[i] * 1e9
                 maps[f"width_{i+1}"][yi, xi] = ws[i] * 1e9

--- a/flimkit/GPU/_base.py
+++ b/flimkit/GPU/_base.py
@@ -8,8 +8,17 @@ from ..FLIM.models import reconvolution_model
 def fit_window(fit_idx, n_bins):
     if fit_idx is None:
         return None
-    idx = np.asarray(fit_idx, dtype=int)
-    if idx.size == n_bins:
+    raw = np.asarray(fit_idx)
+    if raw.ndim != 1 or raw.size == 0:
+        raise ValueError('fit_idx must be a non-empty one-dimensional array')
+    if not np.issubdtype(raw.dtype, np.integer):
+        raise ValueError('fit_idx must contain integer bin indices')
+    idx = raw.astype(int, copy=False)
+    if np.any(idx < 0) or np.any(idx >= n_bins):
+        raise ValueError(f'fit_idx entries must be between 0 and {n_bins - 1}')
+    if np.unique(idx).size != idx.size:
+        raise ValueError('fit_idx must not contain duplicate bins')
+    if np.array_equal(idx, np.arange(n_bins)):
         return None
     return idx
 
@@ -73,6 +82,9 @@ class GPUBackend:
         dist_type,
         min_photons,
         progress_callback,
+        tvb_profile=None,
+        fit_tvb=False,
+        fit_idx=None,
     ):
         raise NotImplementedError
 

--- a/flimkit/GPU/mlx_backend.py
+++ b/flimkit/GPU/mlx_backend.py
@@ -1,6 +1,7 @@
 import numpy as np
 from flimkit.GPU._base import _BackendMixin, fit_window
-from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
+from flimkit.FLIM.fit_tools import (calibrated_chi2, distribution_dof,
+                                    estimate_bg, coates_pileup_correction)
 
 class MLXBackend(_BackendMixin):
 
@@ -205,10 +206,14 @@ class MLXBackend(_BackendMixin):
         progress_callback=None,
         tvb_profile=None,
         fit_tvb=False,
+        fit_idx=None,
     ):
         mx = self._mx
         ny, nx, _ = stack.shape
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
+        win = fit_window(fit_idx, n_bins)
+        n_fit = n_bins if win is None else len(win)
+        flat_fit = flat if win is None else flat[:, win]
         intensity_flat = flat.sum(axis=1)
         valid_mask = intensity_flat >= min_photons
         valid_idx = np.where(valid_mask)[0]
@@ -227,8 +232,9 @@ class MLXBackend(_BackendMixin):
             return maps
         if fit_tvb and tvb_profile is not None:
             maps['tvb_scale'] = np.full((ny, nx), np.nan)
-            U, U_pinv, basis_perp, bb_perp = self._tvb_grid_prep(basis, tvb_profile, n_bins)
-            d_valid = flat[valid_idx]
+            tvb_fit = np.asarray(tvb_profile) if win is None else np.asarray(tvb_profile)[win]
+            U, U_pinv, basis_perp, bb_perp = self._tvb_grid_prep(basis, tvb_fit, n_fit)
+            d_valid = flat_fit[valid_idx]
             d_perp = self._tvb_project_data(d_valid.astype(np.float64), U, U_pinv).astype(np.float32)
             basis_pmx = mx.array(basis_perp)
             bbp_mx = mx.array(bb_perp)
@@ -251,10 +257,10 @@ class MLXBackend(_BackendMixin):
             vz = resid_after @ U_pinv.T
             tvb_v = np.maximum(vz[:, 0], 0.0)
             bg_z = vz[:, 1]
-            B_arr = np.asarray(tvb_profile, dtype=np.float64)
+            B_arr = np.asarray(tvb_fit, dtype=np.float64)
             model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * B_arr[None, :] + bg_z[:, None]
             resid_v = d_valid.astype(np.float64) - model_v
-            chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+            chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / distribution_dof(n_fit, 1, True)
             chi2_cal_v = calibrated_chi2(d_valid, model_v, axis=1)
             yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
             maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
@@ -268,7 +274,7 @@ class MLXBackend(_BackendMixin):
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb_v[good]
             return maps
         bg_flat = self._estimate_bg_batch(flat, valid_mask)
-        dc_flat = np.maximum(flat - bg_flat[:, None], 0.0)
+        dc_flat = np.maximum(flat_fit - bg_flat[:, None], 0.0)
         dc_valid = dc_flat[valid_idx]
         basis_mx = mx.array(basis)
         bb_mx = mx.array(bb_grid)
@@ -288,9 +294,9 @@ class MLXBackend(_BackendMixin):
         tau_int_ns = (tau_v + w_v ** 2 / np.maximum(tau_v, 1e-15)) * 1e9
         basis_best = basis[best_g].astype(np.float64)
         model_v = amp_v[:, None] * basis_best + bg_flat[valid_idx, None]
-        resid_v = dc_valid.astype(np.float64) - model_v
-        chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
-        chi2_cal_v = calibrated_chi2(flat[valid_idx], model_v, axis=1)
+        resid_v = flat_fit[valid_idx].astype(np.float64) - model_v
+        chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / distribution_dof(n_fit, 1, False)
+        chi2_cal_v = calibrated_chi2(flat_fit[valid_idx], model_v, axis=1)
         yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
         maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['width_1'][yi_arr[good], xi_arr[good]] = w_v[good] * 1e9

--- a/flimkit/GPU/torch_backend.py
+++ b/flimkit/GPU/torch_backend.py
@@ -2,7 +2,8 @@ import threading
 
 import numpy as np
 from flimkit.GPU._base import _BackendMixin, fit_window
-from flimkit.FLIM.fit_tools import calibrated_chi2, estimate_bg, coates_pileup_correction
+from flimkit.FLIM.fit_tools import (calibrated_chi2, distribution_dof,
+                                    estimate_bg, coates_pileup_correction)
 
 _MATMUL_PRECISION_LOCK = threading.Lock()
 
@@ -280,10 +281,14 @@ class TorchBackend(_BackendMixin):
         progress_callback=None,
         tvb_profile=None,
         fit_tvb=False,
+        fit_idx=None,
     ):
         torch = self._torch
         ny, nx, _ = stack.shape
         flat = stack.reshape(ny * nx, n_bins).astype(np.float32)
+        win = fit_window(fit_idx, n_bins)
+        n_fit = n_bins if win is None else len(win)
+        flat_fit = flat if win is None else flat[:, win]
         intensity_flat = flat.sum(axis=1)
         valid_mask = intensity_flat >= min_photons
         valid_idx = np.where(valid_mask)[0]
@@ -302,8 +307,9 @@ class TorchBackend(_BackendMixin):
             return maps
         if fit_tvb and tvb_profile is not None:
             maps['tvb_scale'] = np.full((ny, nx), np.nan)
-            U, U_pinv, basis_perp, bb_perp = self._tvb_grid_prep(basis, tvb_profile, n_bins)
-            d_valid = flat[valid_idx]
+            tvb_fit = np.asarray(tvb_profile) if win is None else np.asarray(tvb_profile)[win]
+            U, U_pinv, basis_perp, bb_perp = self._tvb_grid_prep(basis, tvb_fit, n_fit)
+            d_valid = flat_fit[valid_idx]
             d_perp = self._tvb_project_data(d_valid.astype(np.float64), U, U_pinv).astype(np.float32)
             basis_pt = torch.as_tensor(basis_perp, dtype=torch.float32, device=self.device)
             bbp_t = torch.as_tensor(bb_perp, dtype=torch.float32, device=self.device)
@@ -324,10 +330,10 @@ class TorchBackend(_BackendMixin):
             vz = resid_after @ U_pinv.T
             tvb_v = np.maximum(vz[:, 0], 0.0)
             bg_z = vz[:, 1]
-            B_arr = np.asarray(tvb_profile, dtype=np.float64)
+            B_arr = np.asarray(tvb_fit, dtype=np.float64)
             model_v = amp_v[:, None] * basis_best + tvb_v[:, None] * B_arr[None, :] + bg_z[:, None]
             resid_v = d_valid.astype(np.float64) - model_v
-            chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
+            chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / distribution_dof(n_fit, 1, True)
             chi2_cal_v = calibrated_chi2(d_valid, model_v, axis=1)
             yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
             maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
@@ -341,7 +347,7 @@ class TorchBackend(_BackendMixin):
             maps['tvb_scale'][yi_arr[good], xi_arr[good]] = tvb_v[good]
             return maps
         bg_flat = self._estimate_bg_batch(flat, valid_mask)
-        dc_flat = np.maximum(flat - bg_flat[:, None], 0.0)
+        dc_flat = np.maximum(flat_fit - bg_flat[:, None], 0.0)
         dc_valid = dc_flat[valid_idx]
         basis_t = torch.as_tensor(basis,    dtype=torch.float32, device=self.device)
         bb_t = torch.as_tensor(bb_grid,  dtype=torch.float32, device=self.device)
@@ -360,9 +366,9 @@ class TorchBackend(_BackendMixin):
         tau_int_ns = (tau_v + w_v ** 2 / np.maximum(tau_v, 1e-15)) * 1e9
         basis_best = basis[best_g].astype(np.float64)
         model_v = amp_v[:, None] * basis_best + bg_flat[valid_idx, None]
-        resid_v = dc_valid.astype(np.float64) - model_v
-        chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / max(n_bins - 3, 1)
-        chi2_cal_v = calibrated_chi2(flat[valid_idx], model_v, axis=1)
+        resid_v = flat_fit[valid_idx].astype(np.float64) - model_v
+        chi2_v = (resid_v ** 2 / np.maximum(model_v, 1.0)).sum(axis=1) / distribution_dof(n_fit, 1, False)
+        chi2_cal_v = calibrated_chi2(flat_fit[valid_idx], model_v, axis=1)
         yi_arr, xi_arr = np.unravel_index(valid_idx, (ny, nx))
         maps['tau_center_1'][yi_arr[good], xi_arr[good]] = tau_amp_ns[good]
         maps['width_1'][yi_arr[good], xi_arr[good]] = w_v[good] * 1e9

--- a/flimkit/interactive.py
+++ b/flimkit/interactive.py
@@ -541,6 +541,9 @@ def _run_stitch_and_fit(args, progress_callback=None, cancel_event=None, progres
             cost_function=getattr(args, 'cost_function', 'poisson'),
             sigma_max=sigma_max,
             irf_shift_bins=getattr(args, 'irf_shift_bins', 2),
+            fit_start_ns=getattr(args, 'fit_start_ns', None),
+            fit_end_ns=getattr(args, 'fit_end_ns', None),
+            exclude_ns=parse_exclude_ns(getattr(args, 'exclude_ns', None)),
         )
     else:
         print(f'\nFitting summed decay ({args.nexp}-exp, optimizer={args.optimizer})...')
@@ -600,6 +603,7 @@ def _run_stitch_and_fit(args, progress_callback=None, cancel_event=None, progres
                 min_photons=args.min_photons,
                 tau_min_ns=args.tau_min,
                 tau_max_ns=args.tau_max,
+                fit_idx=global_summary.get('fit_idx'),
                 progress_callback=perpixel_progress_cb,
             )
         else:
@@ -1108,6 +1112,7 @@ def _run_flim_fit(args, progress_callback=None, cancel_event=None, progress_wind
                 min_photons=args.min_photons,
                 tau_min_ns=args.tau_min,
                 tau_max_ns=args.tau_max,
+                fit_idx=global_summary.get('fit_idx'),
                 progress_callback=perpixel_progress_cb,
                 tvb_profile=tvb_profile, fit_tvb=fit_tvb,
             )

--- a/flimkit_tests/tests/test_distribution_fit.py
+++ b/flimkit_tests/tests/test_distribution_fit.py
@@ -242,3 +242,234 @@ class TestDistPerPixelCPU:
         assert maps['tau_center_1'].shape == (ny, nx)
         assert maps['tau_mean_amp'].shape == (ny, nx)
         assert not np.all(np.isnan(maps['tau_center_1']))
+
+    @pytest.mark.parametrize('dist_type', ['gaussian', 'lorentzian'])
+    def test_unimodal_grid_scan_ignores_excluded_bins(self, dist_type):
+        from flimkit.FLIM.fitters import fit_summed_dist, fit_per_pixel_dist
+
+        n_bins = 128
+        tcspc_res = MOCK_TCSPC_RES
+        irf_fwhm_ns = MOCK_IRF_FWHM_BINS * tcspc_res * 1e9
+        irf = _irf(n_bins, tcspc_res, irf_fwhm_ns, MOCK_IRF_CENTER)
+        decay = generate_synthetic_gaussian_dist_decay(
+            n_bins=n_bins, tcspc_res=tcspc_res,
+            tau_center_ns=2.0, sigma_ns=0.3,
+            bg=5.0, peak_counts=5_000.0,
+            irf_fwhm_bins=MOCK_IRF_FWHM_BINS,
+            irf_center_bin=MOCK_IRF_CENTER, noise=False,
+        )
+        popt, _ = fit_summed_dist(
+            decay, tcspc_res, n_bins, irf,
+            n_components=1, dist_type=dist_type,
+            fit_bg=True, fit_sigma=False,
+            tau_min_ns=0.1, tau_max_ns=15.0,
+            optimizer='lm_multistart', n_restarts=2, workers=1,
+        )
+        reflected = decay.copy()
+        reflected[80:85] += 2_000.0
+        fit_idx = np.setdiff1d(np.arange(n_bins), np.arange(80, 85))
+        kwargs = dict(
+            tcspc_res=tcspc_res, n_bins=n_bins, irf_prompt=irf,
+            global_popt=popt, n_components=1, dist_type=dist_type,
+            fit_bg=True, fit_sigma=False, min_photons=10,
+            n_tau_grid=10, n_width_grid=8, fit_idx=fit_idx,
+            use_gpu=False,
+        )
+
+        clean = fit_per_pixel_dist(decay[None, None, :], **kwargs)
+        with_reflection = fit_per_pixel_dist(reflected[None, None, :], **kwargs)
+
+        assert with_reflection['intensity'][0, 0] == pytest.approx(reflected.sum())
+        assert with_reflection['intensity'][0, 0] > clean['intensity'][0, 0]
+        for key in ('tau_center_1', 'width_1', 'alpha_1',
+                    'chi2_r', 'calibrated_chi2_r'):
+            np.testing.assert_allclose(clean[key], with_reflection[key], rtol=1e-12)
+
+    def test_use_gpu_false_ignores_supplied_backend(self, monkeypatch):
+        from flimkit.FLIM.fitters import fit_summed_dist, fit_per_pixel_dist
+        from flimkit.FLIM.models import dist_reconvolution_model
+        import flimkit.FLIM.fitters as fitters_module
+
+        class FailingBackend:
+            def batch_dist_scan_unimodal(self, *args, **kwargs):
+                raise AssertionError('backend must not run when use_gpu=False')
+
+        n_bins = 64
+        tcspc_res = 0.05e-9
+        irf = np.zeros(n_bins)
+        irf[0] = 1.0
+        decay = dist_reconvolution_model(
+            np.array([2.0e-9, 0.3e-9, 3_000.0, 0.0, 5.0]),
+            tcspc_res, n_bins, irf, 1, 'gaussian',
+            bg_fixed=None, fit_bg=True, fit_sigma=False,
+        )
+        popt, _ = fit_summed_dist(
+            decay, tcspc_res, n_bins, irf,
+            n_components=1, dist_type='gaussian',
+            fit_bg=True, fit_sigma=False,
+            tau_min_ns=0.1, tau_max_ns=15.0,
+            optimizer='lm_multistart', n_restarts=2, workers=1,
+        )
+
+        bg_input_sizes = []
+        original_estimate_bg = fitters_module.estimate_bg
+
+        def _record_bg_input(decay_input, peak_bin):
+            bg_input_sizes.append(len(decay_input))
+            return original_estimate_bg(decay_input, peak_bin)
+
+        monkeypatch.setattr(fitters_module, 'estimate_bg', _record_bg_input)
+
+        maps = fit_per_pixel_dist(
+            decay[None, None, :], tcspc_res, n_bins, irf,
+            popt, 1, 'gaussian', fit_bg=True, fit_sigma=False,
+            min_photons=10, n_tau_grid=8, n_width_grid=6,
+            use_gpu=False, gpu_backend=FailingBackend(),
+        )
+        cropped = fit_per_pixel_dist(
+            decay[None, None, :], tcspc_res, n_bins, irf,
+            popt, 1, 'gaussian', fit_bg=True, fit_sigma=False,
+            min_photons=10, n_tau_grid=8, n_width_grid=6,
+            use_gpu=False, fit_idx=np.arange(10, 50),
+        )
+        assert np.isfinite(maps['tau_center_1'][0, 0])
+        assert np.isfinite(cropped['tau_center_1'][0, 0])
+        assert bg_input_sizes == [n_bins, n_bins]
+
+    def test_multicomponent_fit_ignores_excluded_bins(self):
+        from flimkit.FLIM.fitters import fit_per_pixel_dist
+        from flimkit.FLIM.models import dist_reconvolution_model
+
+        n_bins = 64
+        tcspc_res = 0.1e-9
+        irf = np.zeros(n_bins)
+        irf[0] = 1.0
+        popt = np.array([
+            0.8e-9, 2.5e-9, 0.15e-9, 0.4e-9,
+            30.0, 20.0, 0.0,
+        ])
+        decay = dist_reconvolution_model(
+            popt, tcspc_res, n_bins, irf, 2, 'gaussian',
+            0.0, False, False,
+        )
+        reflected = decay.copy()
+        reflected[20:25] += 10.0
+        fit_idx = np.setdiff1d(np.arange(n_bins), np.arange(20, 25))
+
+        def _fit(one_decay):
+            return fit_per_pixel_dist(
+                one_decay[None, None, :], tcspc_res, n_bins, irf,
+                popt, n_components=2, dist_type='gaussian',
+                fit_bg=False, fit_sigma=False, min_photons=1,
+                fit_idx=fit_idx, use_gpu=False,
+            )
+
+        clean = _fit(decay)
+        with_reflection = _fit(reflected)
+
+        for key in ('tau_center_1', 'tau_center_2', 'width_1', 'width_2',
+                    'alpha_1', 'alpha_2', 'chi2_r', 'calibrated_chi2_r'):
+            np.testing.assert_allclose(clean[key], with_reflection[key], rtol=1e-10)
+
+    def test_backend_grid_scan_ignores_excluded_bins(self):
+        from flimkit.FLIM.fitters import fit_summed_dist, fit_per_pixel_dist
+        from flimkit.GPU import get_backend
+
+        backend = get_backend()
+        if backend is None:
+            pytest.skip('no accelerated backend available')
+        n_bins = 128
+        tcspc_res = MOCK_TCSPC_RES
+        irf_fwhm_ns = MOCK_IRF_FWHM_BINS * tcspc_res * 1e9
+        irf = _irf(n_bins, tcspc_res, irf_fwhm_ns, MOCK_IRF_CENTER)
+        decay = generate_synthetic_gaussian_dist_decay(
+            n_bins=n_bins, tcspc_res=tcspc_res,
+            tau_center_ns=2.0, sigma_ns=0.3,
+            bg=5.0, peak_counts=5_000.0,
+            irf_fwhm_bins=MOCK_IRF_FWHM_BINS,
+            irf_center_bin=MOCK_IRF_CENTER, noise=False,
+        )
+        popt, _ = fit_summed_dist(
+            decay, tcspc_res, n_bins, irf,
+            n_components=1, dist_type='gaussian',
+            fit_bg=True, fit_sigma=False,
+            tau_min_ns=0.1, tau_max_ns=15.0,
+            optimizer='lm_multistart', n_restarts=2, workers=1,
+        )
+        reflected = decay.copy()
+        reflected[80:85] += 2_000.0
+        fit_idx = np.setdiff1d(np.arange(n_bins), np.arange(80, 85))
+
+        def _fit(one_decay):
+            return fit_per_pixel_dist(
+                one_decay[None, None, :], tcspc_res, n_bins, irf,
+                popt, n_components=1, dist_type='gaussian',
+                fit_bg=True, fit_sigma=False, min_photons=10,
+                n_tau_grid=10, n_width_grid=8, fit_idx=fit_idx,
+                gpu_backend=backend,
+            )
+
+        clean = _fit(decay)
+        with_reflection = _fit(reflected)
+        cpu_clean = fit_per_pixel_dist(
+            decay[None, None, :], tcspc_res, n_bins, irf,
+            popt, n_components=1, dist_type='gaussian',
+            fit_bg=True, fit_sigma=False, min_photons=10,
+            n_tau_grid=10, n_width_grid=8, fit_idx=fit_idx,
+            use_gpu=False,
+        )
+
+        for key in ('tau_center_1', 'width_1', 'alpha_1',
+                    'chi2_r', 'calibrated_chi2_r'):
+            np.testing.assert_allclose(clean[key], with_reflection[key], rtol=1e-6)
+        np.testing.assert_allclose(clean['chi2_r'], cpu_clean['chi2_r'], rtol=1e-5)
+
+    @pytest.mark.parametrize('backend_mode', ['cpu', 'backend'])
+    def test_tvb_grid_scan_ignores_excluded_bins(self, backend_mode):
+        from flimkit.FLIM.fitters import fit_summed_dist, fit_per_pixel_dist
+        from flimkit.GPU import get_backend
+
+        backend = None
+        if backend_mode == 'backend':
+            backend = get_backend()
+            if backend is None:
+                pytest.skip('no accelerated backend available')
+        n_bins = 128
+        tcspc_res = MOCK_TCSPC_RES
+        irf_fwhm_ns = MOCK_IRF_FWHM_BINS * tcspc_res * 1e9
+        irf = _irf(n_bins, tcspc_res, irf_fwhm_ns, MOCK_IRF_CENTER)
+        decay = generate_synthetic_gaussian_dist_decay(
+            n_bins=n_bins, tcspc_res=tcspc_res,
+            tau_center_ns=2.0, sigma_ns=0.3,
+            bg=5.0, peak_counts=5_000.0,
+            irf_fwhm_bins=MOCK_IRF_FWHM_BINS,
+            irf_center_bin=MOCK_IRF_CENTER, noise=False,
+        )
+        popt, _ = fit_summed_dist(
+            decay, tcspc_res, n_bins, irf,
+            n_components=1, dist_type='gaussian',
+            fit_bg=True, fit_sigma=False,
+            tau_min_ns=0.1, tau_max_ns=15.0,
+            optimizer='lm_multistart', n_restarts=2, workers=1,
+        )
+        reflected = decay.copy()
+        reflected[80:85] += 2_000.0
+        fit_idx = np.setdiff1d(np.arange(n_bins), np.arange(80, 85))
+        tvb_profile = np.exp(-np.arange(n_bins, dtype=float) / 30.0)
+
+        def _fit(one_decay):
+            return fit_per_pixel_dist(
+                one_decay[None, None, :], tcspc_res, n_bins, irf,
+                popt, n_components=1, dist_type='gaussian',
+                fit_bg=True, fit_sigma=False, min_photons=10,
+                n_tau_grid=10, n_width_grid=8, fit_idx=fit_idx,
+                use_gpu=False if backend_mode == 'cpu' else 'auto',
+                gpu_backend=backend, tvb_profile=tvb_profile, fit_tvb=True,
+            )
+
+        clean = _fit(decay)
+        with_reflection = _fit(reflected)
+
+        for key in ('tau_center_1', 'width_1', 'alpha_1', 'tvb_scale',
+                    'chi2_r', 'calibrated_chi2_r'):
+            np.testing.assert_allclose(clean[key], with_reflection[key], rtol=1e-6)

--- a/flimkit_tests/tests/test_fit_window_pileup.py
+++ b/flimkit_tests/tests/test_fit_window_pileup.py
@@ -1,11 +1,33 @@
+import ast
+from pathlib import Path
+
 import numpy as np
 import pytest
 from flimkit.FLIM.models import apply_pileup
 from flimkit.FLIM.fit_tools import (coates_pileup_correction, build_fit_idx,
                                     bins_from_ns)
+from flimkit.GPU._base import fit_window
 
 RES = 0.097e-9
 N = 133
+
+
+def test_fit_window_validates_indices():
+    identity = np.arange(8)
+    assert fit_window(identity, 8) is None
+    np.testing.assert_array_equal(fit_window(identity[::-1], 8), identity[::-1])
+    for invalid in (np.array([], dtype=int), np.array([0, 1, 1]),
+                    np.array([-1, 0]), np.array([0, 8])):
+        with pytest.raises(ValueError):
+            fit_window(invalid, 8)
+
+
+def test_distribution_dof_counts_all_fitted_terms():
+    from flimkit.FLIM.fit_tools import distribution_dof
+
+    assert distribution_dof(100, 1, False) == 96
+    assert distribution_dof(100, 1, True) == 95
+    assert distribution_dof(100, 2, False) == 93
 
 def _decay(tau_ns=4.1, total=3e5):
     t = np.arange(N) * RES * 1e9
@@ -129,3 +151,27 @@ class TestExclusionBandInFit:
                                   fit_start_ns=0.5, fit_end_ns=12.0, exclude_ns=ex)
             out.append(s['dof'])
         assert out[1] < out[0]
+
+
+def test_interactive_distribution_calls_propagate_fit_window():
+    import flimkit.interactive as interactive
+
+    tree = ast.parse(Path(interactive.__file__).read_text())
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    summed_calls = [
+        node for node in calls
+        if isinstance(node.func, ast.Name) and node.func.id == 'fit_summed_dist'
+    ]
+    pixel_calls = [
+        node for node in calls
+        if isinstance(node.func, ast.Name) and node.func.id == 'fit_per_pixel_dist'
+    ]
+
+    assert len(summed_calls) == 2
+    assert len(pixel_calls) == 2
+    for node in summed_calls:
+        keywords = {keyword.arg for keyword in node.keywords}
+        assert {'fit_start_ns', 'fit_end_ns', 'exclude_ns'} <= keywords
+    for node in pixel_calls:
+        keywords = {keyword.arg for keyword in node.keywords}
+        assert 'fit_idx' in keywords


### PR DESCRIPTION
## Stack

This draft is intentionally stacked. Please merge in this order:

1. #42
2. #45
3. this pull request

The code branch is based on #45. The pull request targets upstream `main` because #45's head branch exists only in the contributor fork and cannot be selected as an upstream base branch. Until #42 and #45 merge, GitHub will also show their commits in this draft. After each parent merges into `main`, those commits will disappear from this diff automatically.

## What this changes

Make Gaussian and Lorentzian per-pixel distribution fits honour the same fit window and exclusion bands as the summed distribution fit.

The interactive workflows now pass the user-selected start, end and exclusions into `fit_summed_dist`, then pass `global_summary['fit_idx']` into `fit_per_pixel_dist`. The CPU, Torch and MLX paths restrict their distribution basis, residual and fit diagnostics to those selected bins.

Full-decay background estimation, intensity and the `min_photons` mask remain unchanged. Fit indices are validated before slicing. Reduced chi-square uses the selected-bin count and includes centre, width, amplitude, background and optional TVB scale in its degrees of freedom.

Closes #44.

### Investigation

The issue #44 reproduction used a 128-bin decay with a reflection in bins 80 to 84:

```text
Summed distribution fit: 123 of 128 bins used
Per-pixel distribution fit: 128 of 128 bins used
```

`fit_summed_dist` already returned the intended bins in `summary['fit_idx']`, but `fit_per_pixel_dist` had no corresponding argument. Its CPU and backend implementations therefore used the full decay for projection, iterative residuals and diagnostics.

Regression tests were written before the implementation. They first confirmed that:

- `fit_per_pixel_dist` rejected `fit_idx`;
- an excluded reflection changed the CPU multi-component fit;
- an excluded reflection changed the backend one-component fit;
- an excluded reflection changed the CPU time-varying-background fit;
- the interactive workflows did not propagate the window completely.

The implementation then applies one selected-bin representation across those paths. Tests cover Gaussian and Lorentzian one-component fits, multi-component fitting, the accelerated backend, time-varying background, workflow propagation, and the full-decay intensity rule.

## How it was verified

- [x] `cd flimkit_tests && pytest -m "not requires_data"` passes
- [x] Added or updated tests covering the change
- [ ] Checked against real data (say which instrument and format below)

Details:

- Repository verification command: 729 passed, 42 skipped
- Focused distribution and fit-window tests: passed
- Python compilation: passed
- Torch backend excluded-bin tests: passed
- GitHub Actions: pending

## Not verified

- No real vendor file was used. The regression tests use generated synthetic decays and image-mode stacks.
- The MLX implementation was checked for matching array shapes and compiled, but could not be run on this Linux machine.
- No visual GUI check was needed because the change only propagates existing fit-window values and changes fitting calculations.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New or updated file format reader
- [ ] Documentation
- [ ] Build, packaging, or CI
- [ ] Refactor with no behaviour change

## Checklist

- [ ] Branched from `main` with a descriptive branch name
  - Intentionally based on #45 for the requested merge order: #42, then #45, then this pull request.
- [x] The pull request covers one change
- [x] Style matches the surrounding code (4 spaces, single quotes, no padding around `=`, minimal comments)
- [x] User-facing changes are reflected in `Docs/documentation.md`, and in `README.md` if it overlaps
  - Existing fit-window documentation already describes the user-facing controls. `Docs/ROADMAP.md` now records distribution-window support as implemented. README does not overlap.
- [x] No data files, credentials, or large binaries committed
