### PR TITLE
docs: add the Zenodo DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,6 +29,12 @@ authors:
 type: software
 license: MIT
 version: 0.10.1
+date-released: 2026-08-14
+doi: 10.5281/zenodo.21931131
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.21931132
+    description: "Archived release v0.10.1"
 repository-code: "https://github.com/FLIMKit/FLIMKit"
 keywords:
   - FLIM

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![tests](https://github.com/FLIMKit/FLIMKit/actions/workflows/test.yml/badge.svg)](https://github.com/FLIMKit/FLIMKit/actions/workflows/test.yml)
 [![Python versions](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://github.com/FLIMKit/FLIMKit#installation)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
+[![DOI](https://zenodo.org/badge/1168642847.svg)](https://doi.org/10.5281/zenodo.21931131)
 
 > **Warning:** Active development. Cross-validate results with other software before drawing conclusions. API and file formats may change without deprecation.
 


### PR DESCRIPTION
FLIMKit is archived on Zenodo from v0.10.1, so it has a DOI to cite.

The badge and `CITATION.cff` both point at the concept DOI, 10.5281/zenodo.21931131, which always resolves to the newest release. The v0.10.1 record, 10.5281/zenodo.21931132, is listed under `identifiers`, so a specific version can still be cited.

The archive picked up the author list from `CITATION.cff` correctly, Zhen Yuan Yeo included.