### PR TITLE
fix: repair self-intersecting ROI rings on GeoJSON export

### DIFF
--- a/flimkit/UI/roi_tools.py
+++ b/flimkit/UI/roi_tools.py
@@ -169,6 +169,26 @@ class RoiManager:
         return coords
 
     @staticmethod
+    def _outer_boundary(ring: List[List[float]]) -> Optional[List[List[float]]]:
+        from shapely.geometry import MultiPolygon, Polygon
+        polygon = Polygon(ring)
+        if polygon.is_valid:
+            return None
+        repaired = polygon.buffer(0)
+        if isinstance(repaired, MultiPolygon):
+            if not repaired.geoms:
+                return None
+            repaired = max(repaired.geoms, key=lambda part: part.area)
+        if repaired.is_empty or repaired.geom_type != 'Polygon':
+            return None
+        out = [[float(x), float(y)] for x, y in repaired.exterior.coords]
+        if len(out) < 4:
+            return None
+        if out[-1] != out[0]:
+            out.append(out[0][:])
+        return out
+
+    @staticmethod
     def _region_feature(region: Dict) -> Dict:
         tool = region['tool']
         coords = [[float(x), float(y)] for x, y in region['coords']]
@@ -216,6 +236,10 @@ class RoiManager:
             ring = coords.copy()
             if ring[-1] != ring[0]:
                 ring.append(ring[0].copy())
+            outer = RoiManager._outer_boundary(ring)
+            if outer is not None:
+                ring = outer
+                properties['repaired'] = 'self-intersecting'
         else:
             raise ValueError(f'Unsupported ROI tool: {tool}')
 

--- a/flimkit_tests/tests/test_roi_manager.py
+++ b/flimkit_tests/tests/test_roi_manager.py
@@ -191,3 +191,27 @@ class TestRoiManager:
             manager.add_geojson(invalid, mode='replace')
 
         assert [region['name'] for region in manager.get_all_regions()] == ['Existing']
+
+    def test_geojson_repairs_self_intersecting_freehand(self, manager):
+        shapely = pytest.importorskip('shapely.geometry')
+        bowtie = [[0, 0], [10, 10], [10, 0], [0, 10]]
+        manager.add_region('Bowtie', 'freehand', bowtie)
+
+        feature = manager.to_geojson()['features'][0]
+        ring = feature['geometry']['coordinates'][0]
+
+        assert feature['properties']['repaired'] == 'self-intersecting'
+        assert shapely.Polygon(ring).is_valid
+        assert ring[0] == ring[-1]
+
+    def test_geojson_leaves_simple_freehand_untouched(self, manager):
+        shapely = pytest.importorskip('shapely.geometry')
+        square = [[0, 0], [10, 0], [10, 10], [0, 10]]
+        manager.add_region('Square', 'freehand', square)
+
+        feature = manager.to_geojson()['features'][0]
+        ring = feature['geometry']['coordinates'][0]
+
+        assert 'repaired' not in feature['properties']
+        assert ring == [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]]
+        assert shapely.Polygon(ring).is_valid

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ PyWavelets>=1.4.0
 pytest==9.0.2
 scipy==1.17.1
 sdtfile
+shapely==2.1.2
 tifffile
 tqdm==4.67.3
 tkinterdnd2==0.4.3


### PR DESCRIPTION
## What this changes

Freehand ROIs whose outline crosses itself were exported as self-intersecting GeoJSON polygons. RFC 7946 does not allow that, so anything backed by JTS or GEOS rejects them. `to_geojson` now detects an invalid ring, repairs it to its outer boundary, and marks the feature with `properties.repaired = 'self-intersecting'`. Valid rings are returned untouched.

This needs a geometry library, so `shapely==2.1.2` is a new runtime dependency. I tried it first with OpenCV, which is already a dependency, by rasterising the ring and tracing the external contour. It found only one of three bad rings in my test session and the one it repaired was still invalid, because these rings fail on touching vertices and zero-length segments rather than clean crossings. Getting that right by hand is not worth the maintenance.

## How it was verified

- [x] `cd flimkit_tests && pytest -m "not requires_data"` passes
- [x] Added or updated tests covering the change
- [x] Checked against real data (Leica SP8 FALCON, .ptu, via a saved `.roi_session.npz`)

Details:

- 794 passed, up from 792 with the two new tests.
- Five hand-drawn freehand ROIs from a real session, three of which were invalid:

```
freehand-1  520 -> 517 pts   repaired    area kept 100.00%
freehand-2  500 -> 500 pts   untouched
freehand-3  369 -> 369 pts   untouched
freehand-4  495 -> 493 pts   repaired    area kept 100.00%
freehand-5  431 -> 420 pts   repaired    area kept  99.98%
```

- Before this change QuPath refused the whole FeatureCollection with `IllegalArgumentException: Reduction failed, possible invalid input`. One bad feature discarded all five. After it, all five parse.

## Why it was not caught before

FLIMKit does not care, because `compute_region_mask` fills through a matplotlib path, which handles self-intersection by fill rule. Fiji does not care either, because `ij.gui.PolygonRoi` performs no validation. QuPath, PostGIS and shapely all do.

## Type of change

- [x] Bug fix

## Checklist

- [x] Branched from `main` with a descriptive branch name
- [x] The pull request covers one change
- [x] Style matches the surrounding code
- [x] No data files, credentials, or large binaries committed
