### PR TITLE
docs: align on the intensity image

### DIFF
--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -1345,12 +1345,11 @@ FLIMKit expects ROIs in FLIM image-pixel coordinates, so anything drawn on anoth
 
 This needs QuPath's [alignment extension](https://github.com/qupath/qupath-extension-align), which QuPath does not ship and which has to be installed separately. The bridge deliberately contains no alignment code of its own.
 
-The alignment extension does not accept 32-bit float images, and the bridge serves both the intensity and the lifetime map as 32-bit float so that real photon counts and real nanoseconds survive. Align on a 16-bit intensity image of the same field of view instead. The transform is valid for the FLIM images as well, since every image of that field shares one pixel grid, and intensity is the better registration target anyway because it carries the structure a lifetime map often lacks.
+Align on the intensity image rather than the lifetime map. The alignment extension cannot render 32-bit float and throws rather than declining, and the lifetime map has to be float to carry nanoseconds. Photon counts are whole numbers, so intensity crosses as 16-bit whenever that is lossless, which the extension opens without complaint. The transform is valid for the lifetime map as well, since every image of that field shares one pixel grid, and intensity is the better registration target anyway because it carries the structure a lifetime map often lacks.
 
 1. Open the brightfield or mIF image and add the FLIMKit images to the same project.
-2. Add a 16-bit intensity image of the same field of view.
-3. Align the brightfield against it and transfer the annotations onto it.
-4. Send the annotations on the aligned image to FLIMKit.
+2. Align the brightfield against the intensity image and transfer the annotations onto it.
+3. Send the annotations on the aligned image to FLIMKit.
 
 Without the alignment extension you can still exchange images and ROIs, but only between images that already share a coordinate system.
 


### PR DESCRIPTION
The alignment extension cannot render 32-bit float. It throws rather than declining:

```
java.lang.ArrayIndexOutOfBoundsException: Index 99521 out of bounds for length 65536
    at java.awt.image.ComponentColorModel.getRGBComponent
    at qupath.ext.align.gui.ImageAlignmentPane$ImageEntryCell.updateItem
```

The lifetime map has to stay float, since nanoseconds are not integers. Photon counts are whole numbers, so the bridge now sends intensity as 16-bit whenever that is lossless, and the alignment extension opens it.

The co-registration section said to add a separate 16-bit intensity image to the project. That step is gone: align against the intensity image the bridge already provides. The transform is valid for the lifetime map because they share a pixel grid.

Documentation only, no code change in this repository.
