### PR TITLE
Start the GUI on Tk 9, and fall back instead of dying

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- FLIMKit starts on a Tk 9 interpreter. The Windows python.org build of 3.14 ships Tk 9.0 where the macOS build still ships 8.6, and two GUI dependencies are built for Tcl 8.6 only: `tkinterdnd2` 0.4.3 cannot load its `tkdnd` binary, and `TKinterModernThemes` cannot source the Sun Valley theme, so `set_theme` is never defined. Either one killed the launch outright. `tkinterdnd2` moves to 0.6.2 or newer, which carries `tkdnd` 2.10.1 and loads on Tk 8.6.15 and 9.0.4 alike, and `sv-ttk` is a new GUI dependency because it is the maintained home of the same Sun Valley theme and works on both.
+- The GUI falls back rather than dying when a theme or a Tcl package fails at run time. It chose its path from whether the imports succeeded, but both libraries import cleanly and then fail inside Tcl, so nothing caught it. The themed window is now attempted and a `TclError` drops through to the plain path, which tries `sv_ttk` before the stock themes and prefers the platform-native one, `vista` on Windows and `aqua` on macOS, over `clam`. Drag and drop turning itself off no longer stops the window opening. What was turned off and why is printed before the interface takes over stdout.
+
 ## [0.13.1] - 2026-08-21
 
 ### Added

--- a/flimkit/UI/gui.py
+++ b/flimkit/UI/gui.py
@@ -3886,7 +3886,6 @@ if HAS_TKMT:
             self.root.minsize(760, 700)
             self._init_ui()
             self._run_plugin_startups()
-            self.run(cleanresize=False)
 
 class FLIMKitGUIFallback(_UIBuilder):
     def __init__(self, root):
@@ -3895,7 +3894,41 @@ class FLIMKitGUIFallback(_UIBuilder):
         self.root.minsize(760, 700)
         self._init_ui()
         self._run_plugin_startups()
-        self.root.mainloop()
+
+def discard_default_root():
+    root = getattr(tk, '_default_root', None)
+    if root is None:
+        return
+    try:
+        root.destroy()
+    except Exception:
+        pass
+    tk._default_root = None
+
+def plain_root():
+    if HAS_DND:
+        try:
+            from tkinterdnd2 import Tk
+            return Tk()
+        except Exception as exc:
+            print(f'Drag and drop is off, the tkdnd library would not load: {exc}')
+            discard_default_root()
+    return tk.Tk()
+
+def apply_fallback_theme(root):
+    try:
+        import sv_ttk
+        sv_ttk.set_theme('dark')
+        return 'sun-valley through sv_ttk'
+    except Exception:
+        pass
+    style = ttk.Style(root)
+    names = style.theme_names()
+    for theme_name in ('vista', 'aqua', 'clam', 'alt', 'default'):
+        if theme_name in names:
+            style.theme_use(theme_name)
+            return theme_name
+    return style.theme_use()
 
 def launch_gui():
     global GUI_MODE
@@ -3904,20 +3937,21 @@ def launch_gui():
     init_crash_handler()
     from flimkit import plugins
     plugins.ensure_loaded()
+    themed = None
     if HAS_TKMT:
-        app = FLIMKitGUIThemed(theme='sun-valley', mode='dark')
-    else:
-        if HAS_DND:
-            from tkinterdnd2 import Tk
-            root = Tk()
-        else:
-            root = tk.Tk()
-        style = ttk.Style(root)
-        for theme_name in ('clam', 'alt', 'default'):
-            if theme_name in style.theme_names():
-                style.theme_use(theme_name)
-                break
-        app = FLIMKitGUIFallback(root)
+        try:
+            themed = FLIMKitGUIThemed(theme='sun-valley', mode='dark')
+        except tk.TclError as exc:
+            discard_default_root()
+            print(f'The themed window would not start on this Tk: {exc}')
+            print('Falling back. Tk 9 needs tkinterdnd2 0.6.2 or newer and sv-ttk.')
+    if themed is not None:
+        themed.run(cleanresize=False)
+        return
+    root = plain_root()
+    print(f'Theme: {apply_fallback_theme(root)}')
+    FLIMKitGUIFallback(root)
+    root.mainloop()
 
 if __name__ == '__main__':
     launch_gui()

--- a/flimkit_tests/tests/test_gui_launch_fallback.py
+++ b/flimkit_tests/tests/test_gui_launch_fallback.py
@@ -1,0 +1,82 @@
+import pytest
+import tkinter as tk
+from tkinter import ttk
+
+from flimkit.UI import gui
+
+
+@pytest.fixture
+def root():
+    try:
+        found = tk.Tk()
+    except tk.TclError:
+        pytest.skip('no display available for tkinter')
+    found.withdraw()
+    yield found
+    try:
+        found.destroy()
+    except tk.TclError:
+        pass
+
+
+def test_discard_default_root_clears_a_live_root(root):
+    assert tk._default_root is not None
+    gui.discard_default_root()
+    assert tk._default_root is None
+
+
+def test_the_fallback_theme_is_one_the_interpreter_knows(root):
+    chosen = gui.apply_fallback_theme(root)
+    assert chosen
+    if 'sv_ttk' not in chosen:
+        assert chosen in ttk.Style(root).theme_names()
+
+
+def test_a_theme_the_tk_cannot_load_falls_back_rather_than_raising(monkeypatch):
+    if not gui.HAS_TKMT:
+        pytest.skip('TKinterModernThemes is not installed')
+    try:
+        tk.Tk().destroy()
+    except tk.TclError:
+        pytest.skip('no display available for tkinter')
+    gui.discard_default_root()
+    seen = {}
+
+    def refuse(*args, **kwargs):
+        tk.Tk()
+        raise tk.TclError('invalid command name "set_theme"')
+
+    class Stub:
+        def __init__(self, built):
+            seen['root'] = built
+            seen['theme'] = ttk.Style(built).theme_use()
+
+    monkeypatch.setattr(gui.FLIMKitGUIThemed, '__init__', refuse)
+    monkeypatch.setattr(gui, 'FLIMKitGUIFallback', Stub)
+    monkeypatch.setattr(tk.Misc, 'mainloop', lambda self, n=0: seen.setdefault('mainloop', True))
+    monkeypatch.setattr(gui, 'init_crash_handler', lambda: None, raising=False)
+    gui.launch_gui()
+
+    assert seen['mainloop'] is True
+    assert seen['theme']
+    seen['root'].destroy()
+    gui.discard_default_root()
+
+
+def test_a_root_is_built_even_when_tkdnd_will_not_load(monkeypatch):
+    try:
+        tk.Tk().destroy()
+    except tk.TclError:
+        pytest.skip('no display available for tkinter')
+    gui.discard_default_root()
+    monkeypatch.setattr(gui, 'HAS_DND', True)
+    import tkinterdnd2
+
+    def refuse(*args, **kwargs):
+        raise RuntimeError('Unable to load tkdnd library.')
+
+    monkeypatch.setattr(tkinterdnd2.TkinterDnD.Tk, '__init__', refuse)
+    built = gui.plain_root()
+    assert isinstance(built, tk.Tk)
+    built.destroy()
+    gui.discard_default_root()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,9 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = [
-    'tkinterdnd2==0.4.3',
+    'tkinterdnd2>=0.6.2',
     'TKinterModernThemes',
+    'sv-ttk>=2.6.1',
 ]
 notebook = [
     'ipython==9.10.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ sdtfile
 shapely==2.1.2
 tifffile
 tqdm==4.67.3
-tkinterdnd2==0.4.3
+tkinterdnd2>=0.6.2
 xarray==2026.1.0
 TKinterModernThemes
+sv-ttk>=2.6.1


### PR DESCRIPTION
Reported by Yangchen Lin, who could not launch FLIMKit on Windows with Python 3.14 and got a different traceback depending on whether `tkinterdnd2` was installed.

It is not Python 3.14. Reproduced on both:

| | Python | Tk | tkinterdnd2 0.4.3 | TKinterModernThemes 1.10.5 |
|---|---|---|---|---|
| Windows, RTX A2000 box | 3.14.7 | 9.0.4 | `RuntimeError: Unable to load tkdnd library.` | `TclError: invalid command name "set_theme"` |
| macOS | 3.14.3 | 8.6.15 | works | works |

The Windows python.org build of 3.14 ships Tk 9.0 and the macOS build still ships 8.6. `tkinterdnd2` 0.4.3 bundles a `tkdnd` built against Tcl 8.6; `TKinterModernThemes` cannot source the Sun Valley tcl under Tcl 9, so `set_theme` is never defined. Uninstalling `tkinterdnd2` only moved him from the first failure to the second.

`tkinterdnd2` goes to 0.6.2 or newer, which carries `tkdnd` 2.10.1. Measured loading on 9.0.4 and on 8.6.15. `sv-ttk` joins the `gui` extra because it is the maintained home of the same Sun Valley theme and sets `sun-valley-dark` on both.

The second half is a FLIMKit bug whatever the Tk version. `launch_gui` chose its path from `HAS_TKMT` and `HAS_DND`, which are import results, but both libraries import cleanly and fail later inside Tcl, and nothing caught that. The themed window is now attempted and a `TclError` drops through to the plain path that already existed a few lines below, after discarding the half-built root TKMT leaves behind. The plain path tries `sv_ttk` before the stock themes and prefers the platform-native one, `vista` on Windows and `aqua` on macOS, over `clam`. Drag and drop failing no longer stops the window opening, and what was turned off is printed before the interface takes over stdout.

The mainloop moves out of both constructors so that only construction is guarded. Wrapping the mainloop would have turned any `TclError` during use into a second window.

Verified end to end on the Tk 9.0.4 machine: TKMT refuses, the error is caught, the leftover root is discarded, `tkdnd` loads, and `sun-valley-dark` is applied.

Suite is 834 passed, 1 skipped, four of those new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)