### PR TITLE
Lead the install instructions with the compiled app

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- The installation instructions lead with the compiled application rather than with pip, in the README and in the documentation. A facility manager looked at the pip route and gave up before starting, which is a fair reaction from someone who has not installed Python and does not use a terminal. `FLIMKit-windows.zip`, `FLIMKit-macos.zip` and `FLIMKit-linux.zip` have been attached to every release for some time and need none of that, but the line saying so sat at the bottom of the section in parentheses.
+
 ## [0.13.2] - 2026-08-21
 
 ### Fixed

--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -126,7 +126,24 @@ Not decoded yet: T2-mode PTUs (`ptufile` reads the records, but FLIMKit does not
 
 ### Installation
 
-From PyPI, for analysis in scripts, notebooks and the terminal:
+#### No Python, no terminal
+
+Download the build for your machine from the
+[Releases](https://github.com/FLIMKit/FLIMKit/releases/latest) tab, unzip it,
+and run it. Python is inside it, so there is nothing else to install.
+`FLIMKit-windows.zip`, `FLIMKit-macos.zip` and `FLIMKit-linux.zip` are attached
+to every release, built by GitHub Actions on each tag.
+
+On macOS the app is self-signed, so the first launch needs right-click then
+Open. A double-click will be refused.
+
+This route gets the desktop application only. It carries no GPU backend unless
+the build machine had one, which is covered under GPU acceleration in the
+compiled app.
+
+#### From PyPI
+
+For analysis in scripts, notebooks and the terminal:
 
 ```bash
 pip install flimkit                 # readers, fitting, phasors, stitching, the CLI

--- a/README.md
+++ b/README.md
@@ -25,9 +25,25 @@ Desktop GUI showing reconvolution fitting with per-pixel lifetime maps, summed d
 
 ## Installation
 
+### No Python, no terminal
+
+Download the build for your machine from the
+[Releases](https://github.com/FLIMKit/FLIMKit/releases/latest) tab, unzip it,
+and run it. Python is inside it, so there is nothing else to install.
+`FLIMKit-windows.zip`, `FLIMKit-macos.zip` and `FLIMKit-linux.zip` are attached
+to every release.
+
+On macOS the app is self-signed, so the first launch needs right-click then
+Open. A double-click will be refused.
+
+This route gets the desktop application only. Everything below is for scripting,
+the terminal, or GPU fitting.
+
+### From PyPI
+
 Python ≥ 3.12 required (3.14 recommended, official builds use 3.14).
 
-From PyPI, for analysis in scripts, notebooks and the terminal:
+For analysis in scripts, notebooks and the terminal:
 
 ```bash
 pip install flimkit            # readers, fitting, phasors, stitching, the CLI
@@ -52,8 +68,6 @@ For development work (PyInstaller + test dependencies):
 ```bash
 python install.py --dev
 ```
-
-Or download the compiled app from the Releases tab (no Python needed).
 
 ## Docker / TrueNAS SCALE
 


### PR DESCRIPTION
Yangchen asked a facility manager to install FLIMKit from the GitHub instructions. She read them and gave up on the spot, not knowing what a terminal was or that Python had to be installed first.

She did not need any of it. Every release has `FLIMKit-windows.zip`, `FLIMKit-macos.zip` and `FLIMKit-linux.zip` attached, each carrying Python inside it. That was already true. It was one parenthesised line at the bottom of the Installation section, under pip, a clone, `install.py` and the development extras, which is not where someone who does not use a terminal is going to find it.

It is the first thing in the section now, in the README and in `Docs/documentation.md`, with the macOS right-click-then-Open caveat next to it, and it says what it does not get you so the pip route still reads as the one for scripting and GPU work.

`Docs/build_wiki.py` splits into 17 pages with no anchor left unrewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)