### PR TITLE
docs: describe the QuPath phasor window and its settings

### DIFF
--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -1412,8 +1412,30 @@ From QuPath:
 - **Add FLIMKit images to project** puts the intensity and lifetime maps into the open project as float32 images, in real units rather than a colourmapped render, so they can sit beside a brightfield or mIF image in the viewer grid.
 - **Send annotations to FLIMKit** posts the annotations on the current image.
 - **Fetch ROIs from FLIMKit** pulls FLIMKit's regions in.
+- **Phasor** opens the phasor window for the image in view.
 
 From FLIMKit, the **Send to QuPath** button in the ROI panel reports whether QuPath has connected and what is being served. If no QuPath has paired it says so rather than failing quietly.
+
+### The phasor window
+
+The phasor window draws the same density plot the desktop app does, for whichever time-domain file QuPath has open. Click on it to place an elliptical cursor and drag to move one. Each cursor reports its pixel count, phase and modulation lifetimes, and mean G and S, and six is the limit because that is how many colours the palette has.
+
+**Create annotations** turns the cursors into QuPath annotations on the image, one per cursor, classified as `Phasor` and carrying the same measurements the cursor list shows. The phasor is computed on binned pixels, so the label image comes back at that resolution and is traced with the binning as its downsample, which puts the outlines in full-resolution image coordinates.
+
+**Settings** picks the filter and the IRF.
+
+| Setting | Values | What it does |
+|---|---|---|
+| Phasor filter | `none`, `gaussian`, `median`, `wavelet`, plus anything a plugin registers | Spatial smoothing of the G and S coordinates |
+| Gaussian sigma | 0.1 to 10 px | Width of the gaussian kernel |
+| Median window | 3 to 15 px | Size of the median window |
+| IRF calibration | `none`, plus every machine IRF installed | Rotates and scales the phasor onto the calibrated frame |
+
+Calibration runs before filtering, the same order the desktop app and `phasor_cli.py` use, so the same file gives the same coordinates whichever front end you drive it from.
+
+The IRF list is empty on a fresh install. A machine IRF describes one microscope, so none are distributed with FLIMKit, and you have to measure your own under **Tools > Machine IRF Builder** in the desktop app before it appears here. An uncalibrated phasor is still useful for comparing populations within one image, but the absolute lifetimes it reports are not.
+
+Changing a setting recomputes the phasor rather than reusing what was already on screen. The bridge caches per dataset and per setting, so switching back to a combination you have already looked at is immediate.
 
 ### Without the FLIMKit window
 


### PR DESCRIPTION
## What this changes

The QuPath Bridge section never mentioned the phasor window. This adds a subsection covering the cursors, the annotations they produce, and the filter and IRF settings.

It says that calibration runs before filtering, and that the IRF list is empty until you've built a machine IRF, since none ship with FLIMKit.

Describes flimkit-qupath-bridge 0.5.0 (FLIMKit/flimkit-qupath-bridge#12), so it should land alongside that release rather than before it.

## How it was verified

- [ ] `cd flimkit_tests && pytest -m "not requires_data"` passes
- [ ] Added or updated tests covering the change
- [ ] Checked against real data (say which instrument and format below)

Details:

`python Docs/build_wiki.py /tmp/wiki-preview` splits cleanly into 17 pages plus `Home.md` and `_Sidebar.md`, and `grep -rn '](#' /tmp/wiki-preview` returns nothing, so no internal anchor failed to rewrite.

The FLIMKit test suite was not run. This changes one markdown file and no Python.

The behaviour being described was verified on the bridge side, not here: 232 passed with `FLIMKIT_TEST_PTU` pointed at a synthetic PTU.

## Not verified

The phasor window has not been driven by hand in QuPath with a filter and an IRF applied. The settings are covered by the bridge's own tests and the extension builds, but nobody has clicked through the dialog on a real image.

## Type of change

- [x] Documentation

## Checklist

- [x] Branched from `main` with a descriptive branch name
- [x] The pull request covers one change
- [x] Style matches the surrounding code (4 spaces, single quotes, no padding around `=`, minimal comments)
- [x] User-facing changes are reflected in `Docs/documentation.md`, and in `README.md` if it overlaps
- [x] No data files, credentials, or large binaries committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
