### PR TITLE
Bring the roadmap back in line, and document the freehand region

### DIFF
--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -20,9 +20,6 @@ The registry half of the add-on system shipped in 0.10.0. Analysis tools, file f
 
 Models and cost functions are what is left, and they are one job rather than two. The differential evolution costs are twelve hand-written classes covering model against cost function against reparameterisation, so both hooks need the same groundwork first: a parameter-layout object, and one generic cost class in place of the twelve. Tracked in issue #3.
 
-### 5. Freehand phasor regions in QuPath
-The bridge accepts a polygon cursor already. `cursor_masks` dispatches `type: 'polygon'` and tests each pixel against the outline in `(g, s)`, and that path is covered by tests. What is missing is the QuPath side: the phasor canvas offers elliptical cursors only, with no way to draw an outline. Sending the vertices as GeoJSON in `(g, s)` would reuse the wire format ROIs already use rather than inventing a second one.
-
 ## Medium Priority - To Do
 
 ### 1. Auto-Detect Regions
@@ -56,5 +53,5 @@ Listed so the sections above stay a list of work and not a history.
 - 0.13.x: pile-up in the forward model, background as a fitted term, nanosecond parameterisation for free-tau per-pixel fits, float32 per-pixel chi-squared, a per-backend GPU block budget, and a GUI that starts on Tk 9.
 - 0.12.0: per-pixel GPU fitting, device pinning, and the expanded GPU benchmark.
 - 0.11.0 and 0.10.x: the plugin registry, the QuPath and FIJI bridges, `batch_fixed_tau` windowing, and the anisotropy spin-out.
-- QuPath bridge 0.5.0: phasor filtering and IRF calibration driven from QuPath, and a phasor cache keyed on the settings that produced it.
+- QuPath bridge 0.5.0: phasor filtering and IRF calibration driven from QuPath, freehand regions traced on the phasor plot, and a phasor cache keyed on the settings that produced it.
 - GPU per-pixel fitting with a fit window: fixed-tau and the one-exponential grid scan honour a fit window and exclusion bands on the GPU, and free-tau honours it by slicing the residual. Two cases still fall back and say so: one-exponential with a time-varying background, and tail fits, whose window starts at the fitted `t0` rather than at a bin the user chose.

--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # FLIMKit Development Roadmap
 
-**Last Updated:** August 11, 2026
+**Last Updated:** August 24, 2026
 
 ## High Priority - To Do
 
@@ -8,24 +8,20 @@
 UI controls to filter/select regions by tau, photon count, and other statistics. Display filtered results.
 
 ### 2. Stat Histograms
-Histogram visualization for ROI statistical distributions (tau, photon counts, etc.).
+Histogram visualization for ROI statistical distributions (tau, photon counts, etc.). The phasor panel has its own density histogram, which is a different thing and does not cover this.
 
 ### 3. Reading pixel data out of a Leica `.lif`
 The metadata already comes out. Tile positions and pixel size are read from the XML header (`parse_lif_tile_positions`, `get_pixel_size_from_lif`), and those positions were checked bit-identical to the `.xlif` ones. The FLIM data is the part that is out of reach: it sits in a proprietary container inside the same file, so a scan saved only into a `.lif` still needs its `.ptu` files alongside it. Requested by a collaborator working from LAS X saved files.
 
 Reading their XML header is one thing, decoding their data container is another, and I am not going to do the second without Leica documenting it and agreeing to it. Becker & Hickl, ISS and Photonscore all supported. After that the remaining unknown is the `_s{N}` series flattening order, which decides how a series index maps onto the tile grid.
 
-### 4. Add-on system
-Let users define their own decay models and cost functions, and let analysis tools, file formats and phasor filters register themselves the same way. Built in house as a small `flimkit.plugins` registry rather than by pulling in a plugin framework, since there is no packaging metadata for entry points to hang off and the PyInstaller build could not discover them anyway.
+### 4. Custom decay models and cost functions
+The registry half of the add-on system shipped in 0.10.0. Analysis tools, file formats, phasor filters, panel buttons and startup hooks all register themselves through `flimkit.plugins`, built in house as a small registry rather than by pulling in a plugin framework, since there is no packaging metadata for entry points to hang off and the PyInstaller build could not discover them anyway.
 
-Models and cost functions are the goal, and they are one job rather than two. The differential evolution costs are twelve hand-written classes covering model against cost function against reparameterisation, so both hooks need the same groundwork first: a parameter-layout object, and one generic cost class in place of the twelve. Tracked in issue #3. Tools, formats and filters come first, since they are close to free by comparison and they prove the registry.
+Models and cost functions are what is left, and they are one job rather than two. The differential evolution costs are twelve hand-written classes covering model against cost function against reparameterisation, so both hooks need the same groundwork first: a parameter-layout object, and one generic cost class in place of the twelve. Tracked in issue #3.
 
-### 5. GPU per-pixel fitting with a fit window
-Fixed-tau and the one-exponential grid scan now honour a fit window and exclusion bands on the GPU, so dropping a reflection peak out of the fit no longer costs the GPU path. `intensity` and the `min_photons` mask stay computed over the whole decay, as on the CPU, and CPU/GPU parity is tested with a window active.
-
-Free-tau honours it too, by slicing the residual: that path is `least_squares` per pixel across a thread pool rather than GPU maths, so there was no kernel to change. Two cases still fall back and say so: one-exponential with a time-varying background, and tail fits. The tail fit is different, since its window starts at the fitted `t0` rather than at a bin the user chose.
-
-Per-pixel Gaussian and Lorentzian distribution fits now receive the same selected bins as the summed fit. The CPU, Torch and MLX paths restrict the distribution projection, iterative residual and fit diagnostics to those bins, while background estimation, `intensity` and the `min_photons` mask continue to use the whole decay.
+### 5. Freehand phasor regions in QuPath
+The bridge accepts a polygon cursor already. `cursor_masks` dispatches `type: 'polygon'` and tests each pixel against the outline in `(g, s)`, and that path is covered by tests. What is missing is the QuPath side: the phasor canvas offers elliptical cursors only, with no way to draw an outline. Sending the vertices as GeoJSON in `(g, s)` would reuse the wire format ROIs already use rather than inventing a second one.
 
 ## Medium Priority - To Do
 
@@ -44,7 +40,21 @@ Move the desktop GUI off tkinter and onto Panel. The spike passed and the early 
 ### 5. TVB grid-scan cost sensitivity
 The per-pixel TVB grid scan selects a lifetime by taking the minimum over projected costs that sit very close together. TF32 rounding on CUDA was enough to move the selected bin by 0.06 to 0.13 ns, which is now prevented by forcing full float32 precision for those two matrix multiplications (#30, #34). That fixes CPU and GPU agreement but not the sensitivity itself. Worth reporting how flat the cost curve is near the minimum, or refining the grid around it, so a near-degenerate fit is visible rather than silent.
 
+### 6. A batched GPU kernel for free-tau per-pixel fits
+`batch_free_tau_fit` binds the device module and then runs `least_squares` per pixel on the CPU, so free-tau per-pixel fitting gets no GPU work at all. A real batched Levenberg-Marquardt kernel is about a week and is parked rather than scheduled.
+
 ## Known issues
 
-- **Importing ROIs from GeoJSON** - When importing ROIs from GeoJSON, only the exterior geometry is imported. Shapes with holes lose the hole geometry and are imported as the outer boundary only.
+- **Importing ROIs from GeoJSON** - When importing ROIs from GeoJSON, only the exterior geometry is imported. `flimkit/utils/roi.py` takes the outer ring and drops the rest, so shapes with holes are imported as the outer boundary only.
 - **CI test depends on a network download** - `test_stitch_and_fit_workflow` builds a tissue mask, which makes Cellpose fetch model weights at run time. When the GitHub runner is rate limited the test fails with HTTP 429 and the whole run goes red for reasons unrelated to the change being tested. Caching the weights or stubbing the fetch would fix it.
+- **The ISS `.ifli` offset table is unsettled** - `.ifli` goes through `lfdfiles`, which resolved the reader question but not the underlying one: the specification copies I have disagree with the library about where the phasor offset table starts. I have no ISS acquisition to check against, so the numbers `.ifli` returns should be cross-checked before they are relied on. The same caveat is on the readers in the documentation.
+
+## Recently shipped
+
+Listed so the sections above stay a list of work and not a history.
+
+- 0.13.x: pile-up in the forward model, background as a fitted term, nanosecond parameterisation for free-tau per-pixel fits, float32 per-pixel chi-squared, a per-backend GPU block budget, and a GUI that starts on Tk 9.
+- 0.12.0: per-pixel GPU fitting, device pinning, and the expanded GPU benchmark.
+- 0.11.0 and 0.10.x: the plugin registry, the QuPath and FIJI bridges, `batch_fixed_tau` windowing, and the anisotropy spin-out.
+- QuPath bridge 0.5.0: phasor filtering and IRF calibration driven from QuPath, and a phasor cache keyed on the settings that produced it.
+- GPU per-pixel fitting with a fit window: fixed-tau and the one-exponential grid scan honour a fit window and exclusion bands on the GPU, and free-tau honours it by slicing the residual. Two cases still fall back and say so: one-exponential with a time-varying background, and tail fits, whose window starts at the fitted `t0` rather than at a bin the user chose.

--- a/Docs/documentation.md
+++ b/Docs/documentation.md
@@ -1437,6 +1437,8 @@ From FLIMKit, the **Send to QuPath** button in the ROI panel reports whether QuP
 
 The phasor window draws the same density plot the desktop app does, for whichever time-domain file QuPath has open. Click on it to place an elliptical cursor and drag to move one. Each cursor reports its pixel count, phase and modulation lifetimes, and mean G and S, and six is the limit because that is how many colours the palette has.
 
+**Draw region** switches the plot to tracing. Drag to draw an outline and it becomes a cursor when you let go, so a population that is not an ellipse can still be selected. The outline goes to FLIMKit as a polygon in G and S, points closer than three pixels apart are dropped, and fewer than three points is not a region. Drawn regions cannot be dragged afterwards. Remove and redraw instead. The button releases itself after each outline, so the plot goes back to placing ellipses.
+
 **Create annotations** turns the cursors into QuPath annotations on the image, one per cursor, classified as `Phasor` and carrying the same measurements the cursor list shows. The phasor is computed on binned pixels, so the label image comes back at that resolution and is traced with the binning as its downsample, which puts the outlines in full-resolution image coordinates.
 
 **Settings** picks the filter and the IRF.


### PR DESCRIPTION
## What this changes

Two roadmap items were filed as To Do and both were largely done. The add-on system's registry shipped in 0.10.0, so what's left is the models and cost functions in issue #3. The GPU fit window item read as a completed changelog entry, so it moves to a new Recently shipped section.

Adds the batched free-tau GPU kernel as parked rather than scheduled, and writes down the ISS `.ifli` offset discrepancy as a known issue. It was only living in the reader warning, and it's a correctness risk with no ISS acquisition here to check against.

Also documents the freehand phasor region in the QuPath Bridge section, which is FLIMKit/flimkit-qupath-bridge#15.

## How it was verified

- [ ] `cd flimkit_tests && pytest -m "not requires_data"` passes
- [ ] Added or updated tests covering the change
- [ ] Checked against real data (say which instrument and format below)

Details:

`python Docs/build_wiki.py /tmp/wiki-preview` splits cleanly into 17 pages plus `Home.md` and `_Sidebar.md`, and `grep -rn '](#' /tmp/wiki-preview` returns nothing, so no internal anchor failed to rewrite.

The FLIMKit test suite was not run. This changes two markdown files and no Python.

The roadmap claims were checked against code rather than assumed. Filter by Stats, Stat Histograms and Auto-Detect Regions are all genuinely still undone, and `flimkit/utils/roi.py` still takes the outer ring only, so the GeoJSON holes issue stands.

The phasor window behaviour being described was driven by hand in QuPath against a real file.

## Not verified

Nothing beyond the above.

## Type of change

- [x] Documentation

## Checklist

- [x] Branched from `main` with a descriptive branch name
- [x] The pull request covers one change
- [x] Style matches the surrounding code (4 spaces, single quotes, no padding around `=`, minimal comments)
- [x] User-facing changes are reflected in `Docs/documentation.md`, and in `README.md` if it overlaps
- [x] No data files, credentials, or large binaries committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
